### PR TITLE
feat - add LIBXSMM_VERSION_GE

### DIFF
--- a/include/libxsmm.h
+++ b/include/libxsmm.h
@@ -34,6 +34,23 @@
 #define LIBXSMM_VERSION_PATCH  LIBXSMM_CONFIG_VERSION_PATCH
 
 /**
+ * Macro to check minimum version requiremnts in code,
+ * for example:
+ * #if LIBXSMM_VERSION_GE(1, 17, 0, 0)
+ * // code requiring version 1.17 or later
+ * #else
+ * // fallback code
+ * #endif
+*/
+#define LIBXSMM_VERSION_GE(major, minor, update, patch)                           \
+  (LIBXSMM_VERSION_MAJOR > major ||                                               \
+   (LIBXSMM_VERSION_MAJOR == major &&                                             \
+    (LIBXSMM_VERSION_MINOR > minor ||                                             \
+     (LIBXSMM_VERSION_MINOR == minor &&                                           \
+      (LIBXSMM_VERSION_UPDATE > update ||                                         \
+       (LIBXSMM_VERSION_UPDATE == update && LIBXSMM_VERSION_PATCH >= patch ))))))
+
+/**
  * The following interfaces shall be explicitly included,
  * i.e., separate from libxsmm.h:
  * - libxsmm_intrinsics_x86.h


### PR DESCRIPTION
I find this macro handy for handling minor API changes. 

We just made a version for LIBXSMM versioning in libCEED so I thought I'd contribute it back. See:

https://github.com/CEED/libCEED/pull/882/commits/318af0d1a760765edef6872663e190e11f82cd8e