### PR TITLE
Add performance testing to eltwise-correctness tests

### DIFF
--- a/samples/eltwise/eltwise_binary_simple.c
+++ b/samples/eltwise/eltwise_binary_simple.c
@@ -14,6 +14,8 @@
 #include <stdio.h>
 #include <math.h>
 
+#include "eltwise_perf_tester.h"
+
 #define NO_BCAST 0
 #define ROW_BCAST_IN0 1
 #define COL_BCAST_IN0 2
@@ -162,6 +164,7 @@ int test_binary_op_f32_f32( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasin
   libxsmm_matdiff_info norms_out;
   libxsmm_meltw_binary_type  binary_type;
   char opname[256];
+  int bandwidthPerIteration, flopsPerIteration;
 
   set_opname(op, opname);
   set_binarytype(op, &binary_type);
@@ -175,16 +178,18 @@ int test_binary_op_f32_f32( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasin
     exit(-1);
   }
 
-  libxsmm_rng_set_seed(1);
-
   in        = (float*) libxsmm_aligned_malloc( sizeof(float)*N*LIBXSMM_MAX(M,ldi),   64);
   in2       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*LIBXSMM_MAX(M,ldi),   64);
   out       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*ldo,   64);
   out_gold  = (float*) libxsmm_aligned_malloc( sizeof(float)*N*ldo,   64);
   _in       = in;
-  _in2      = in2;
+  _in2 = in2;
 
-   /* init in */
+  BENCHMARK_INIT();
+
+  libxsmm_rng_set_seed(1);
+
+  /* init in */
   for ( i = 0; i < N; ++i ) {
     for ( j = 0; j < ldi; ++j ) {
       in[(i*ldi)+j] = (float)libxsmm_rng_f64();
@@ -309,11 +314,18 @@ int test_binary_op_f32_f32( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasin
   printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
   printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
   printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-  printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+  printf("Check-norm    : %.24f\n", norms_out.normf_rel);
+
+  flopsPerIteration = M * N * (binary_type == LIBXSMM_MELTW_TYPE_BINARY_MULADD ? 2 : 1);
+  /* muladd had 4x bandwidth instead of 3x, because 3x load + 1x store instead of 2x load + 1x store */
+  bandwidthPerIteration = M * N * (binary_type == LIBXSMM_MELTW_TYPE_BINARY_MULADD ? 4 : 3) * sizeof(float);
+  BENCHMARK_RUN(binary_kernel(&binary_param), bandwidthPerIteration, flopsPerIteration);
 
   if ( norms_out.normf_rel > 0.00001 ) {
     ret = EXIT_FAILURE;
   }
+
+  BENCHMARK_FINALIZE();
 
   libxsmm_free( out_gold );
   libxsmm_free( out );
@@ -341,6 +353,7 @@ int test_binary_op_bf16_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blas
   libxsmm_matdiff_info norms_out;
   libxsmm_meltw_binary_type  binary_type;
   char opname[256];
+  int bandwidthPerIteration, flopsPerIteration;
 
   set_opname(op, opname);
   set_binarytype(op, &binary_type);
@@ -354,8 +367,6 @@ int test_binary_op_bf16_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blas
     exit(-1);
   }
 
-  libxsmm_rng_set_seed(1);
-
   in          = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*LIBXSMM_MAX(M,ldi), 64);
   in2         = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*LIBXSMM_MAX(M,ldi), 64);
   out         = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*ldo, 64);
@@ -363,15 +374,19 @@ int test_binary_op_bf16_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blas
   f32out      = (float*)            libxsmm_aligned_malloc( sizeof(float)*N*ldo,            64);
   f32out_gold = (float*)            libxsmm_aligned_malloc( sizeof(float)*N*ldo,            64);
    _in        = in;
-  _in2        = in2;
+   _in2 = in2;
 
-  /* init in */
-  for ( i = 0; i < N; ++i ) {
-    for ( j = 0; j < ldi; ++j ) {
-      union libxsmm_bfloat16_hp bf16_hp;
-      bf16_hp.f = (float)libxsmm_rng_f64();
-      in[(i*ldi)+j] = bf16_hp.i[1];
-    }
+   libxsmm_rng_set_seed(1);
+
+   BENCHMARK_INIT();
+
+   /* init in */
+   for (i = 0; i < N; ++i) {
+     for (j = 0; j < ldi; ++j) {
+       union libxsmm_bfloat16_hp bf16_hp;
+       bf16_hp.f = (float)libxsmm_rng_f64();
+       in[(i * ldi) + j] = bf16_hp.i[1];
+     }
   }
 
   for ( i = 0; i < N; ++i ) {
@@ -501,11 +516,18 @@ int test_binary_op_bf16_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blas
   printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
   printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
   printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-  printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+  printf("Check-norm    : %.24f\n", norms_out.normf_rel);
+
+
+  flopsPerIteration = M * N * (binary_type == LIBXSMM_MELTW_TYPE_BINARY_MULADD ? 2 : 1);
+  bandwidthPerIteration = M * N * 3 * sizeof(libxsmm_bfloat16);
+  BENCHMARK_RUN(binary_kernel(&binary_param), bandwidthPerIteration, flopsPerIteration);
 
   if ( norms_out.normf_rel > 0.005 ) {
     ret = EXIT_FAILURE;
   }
+
+  BENCHMARK_FINALIZE();
 
   libxsmm_free( out_gold );
   libxsmm_free( out );
@@ -524,7 +546,7 @@ int test_binary_op_bf16_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blas
 }
 
 int test_binary_op_f32_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint ldi, libxsmm_blasint ldo, unsigned int op, unsigned int use_bcast) {
-  float *in,*_in, *in2, *_in2;
+  float *in, *_in, *in2, *_in2;
   libxsmm_bfloat16 *out, *out_gold;
   float *f32out, *f32out_gold;
   unsigned int i, j;
@@ -535,6 +557,7 @@ int test_binary_op_f32_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
   libxsmm_matdiff_info norms_out;
   libxsmm_meltw_binary_type  binary_type;
   char opname[256];
+  int bandwidthPerIteration, flopsPerIteration;
 
   set_opname(op, opname);
   set_binarytype(op, &binary_type);
@@ -548,8 +571,6 @@ int test_binary_op_f32_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
     exit(-1);
   }
 
-  libxsmm_rng_set_seed(1);
-
   in          = (float*) libxsmm_aligned_malloc( sizeof(float)*N*LIBXSMM_MAX(M,ldi),                       64);
   in2         = (float*) libxsmm_aligned_malloc( sizeof(float)*N*LIBXSMM_MAX(M,ldi),                       64);
   out         = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*ldo, 64);
@@ -558,6 +579,10 @@ int test_binary_op_f32_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
   f32out_gold = (float*)            libxsmm_aligned_malloc( sizeof(float)*N*ldo,            64);
   _in         = in;
   _in2        = in2;
+
+  BENCHMARK_INIT();
+
+  libxsmm_rng_set_seed(1);
 
   /* init in */
   for ( i = 0; i < N; ++i ) {
@@ -690,11 +715,18 @@ int test_binary_op_f32_bf16( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
   printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
   printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
   printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-  printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+  printf("Check-norm    : %.24f\n", norms_out.normf_rel);
+
+
+  flopsPerIteration = M * N * (binary_type == LIBXSMM_MELTW_TYPE_BINARY_MULADD ? 2 : 1);
+  bandwidthPerIteration = M * N * (2 * sizeof(float)  + sizeof(libxsmm_bfloat16));
+  BENCHMARK_RUN(binary_kernel(&binary_param), bandwidthPerIteration, flopsPerIteration);
 
   if ( norms_out.normf_rel > 0.005 ) {
     ret = EXIT_FAILURE;
   }
+
+  BENCHMARK_FINALIZE();
 
   libxsmm_free( out_gold );
   libxsmm_free( out );
@@ -723,6 +755,7 @@ int test_binary_op_bf16_f32( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
   libxsmm_matdiff_info norms_out;
   libxsmm_meltw_binary_type  binary_type;
   char opname[256];
+  int bandwidthPerIteration, flopsPerIteration;
 
   set_opname(op, opname);
   set_binarytype(op, &binary_type);
@@ -736,14 +769,16 @@ int test_binary_op_bf16_f32( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
     exit(-1);
   }
 
-  libxsmm_rng_set_seed(1);
-
   in        = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*LIBXSMM_MAX(M,ldi),   64);
   in2       = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*LIBXSMM_MAX(M,ldi),   64);
   out       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*ldo,   64);
   out_gold  = (float*) libxsmm_aligned_malloc( sizeof(float)*N*ldo,   64);
   _in       = in;
-  _in2      = in2;
+  _in2 = in2;
+
+  BENCHMARK_INIT();
+
+  libxsmm_rng_set_seed(1);
 
   /* init in */
   for ( i = 0; i < N; ++i ) {
@@ -875,9 +910,16 @@ int test_binary_op_bf16_f32( libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasi
   printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
   printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
 
+
+  flopsPerIteration = M * N * (binary_type == LIBXSMM_MELTW_TYPE_BINARY_MULADD ? 2 : 1);
+  bandwidthPerIteration = M * N * (2 * sizeof(libxsmm_bfloat16) + sizeof(float));
+  BENCHMARK_RUN(binary_kernel(&binary_param), bandwidthPerIteration, flopsPerIteration);
+
   if ( norms_out.normf_rel > 0.005 ) {
     ret = EXIT_FAILURE;
   }
+
+  BENCHMARK_FINALIZE();
 
   libxsmm_free( out_gold );
   libxsmm_free( out );

--- a/samples/eltwise/eltwise_perf_tester.h
+++ b/samples/eltwise/eltwise_perf_tester.h
@@ -1,0 +1,129 @@
+/******************************************************************************
+* Copyright (c) Friedrich-Schiller University Jena - All rights reserved.     *
+* This file is part of the LIBXSMM library.                                   *
+*                                                                             *
+* For information on the license, see the LICENSE file.                       *
+* Further information: https://github.com/hfp/libxsmm/                        *
+* SPDX-License-Identifier: BSD-3-Clause                                       *
+******************************************************************************/
+/* Antonio Noack (FSU Jena)
+******************************************************************************/
+
+/**
+ * This file should be compatible with all correctness tests, and used as an additional benchmark.
+ * You need to define the following values as arguments to BENCHMARK_RUN()
+ *  - BENCHMARKED_CALL your kernel call, e.g. unary_kernel( &unary_param );
+ *  - FLOPS_PER_ITERATION as the number of operations inside your kernel call
+ *  - BANDWIDTH_PER_ITERATION as the number of bytes transferred inside your kernel call, shall be > 0
+ *
+ * This benchmarking only works if no architectures shall be compared, or calling the kernel and creating the kernel need to be in the same function.
+ * You can disable benchmarking by setting BENCHMARK_DURATION to 0.
+ */
+
+/*
+
+Notes:
+
+compiling libxsmm without BLAS:
+make BLAS=0 STATIC=0 -j 48
+
+set target architecture:
+LIBXSMM_TARGET=A64FX
+
+create object dumps:
+LIBXSMM_VERBOSE=-1
+
+inspect a dumped file:
+objdump -D -b binary -maarch64 <fileName>
+
+*/
+
+/* how many architectures will be tested at max; more archs would need to be implemented in getBenchmarkedArch() */
+#define MAX_BENCHMARK_ARCHITECTURES 2
+
+const char* getBenchmarkedArch(int index) {
+  if (index < 0 || index >= MAX_BENCHMARK_ARCHITECTURES) return 0;
+  static const char* archs[MAX_BENCHMARK_ARCHITECTURES] = { NULL };
+  int i;
+  if (archs[0] == 0) {
+    /* init all other architectures to zero, just in case */
+    for (i = 1; i < MAX_BENCHMARK_ARCHITECTURES; i++) {
+      archs[i] = NULL;
+    }
+    /* find main architecture */
+    archs[0] = libxsmm_get_target_arch();
+    /* find secondary/comparison architectures (currently only one) */
+    const char* arch1 = getenv("ARCH1");
+    if (arch1) {
+      libxsmm_set_target_arch(arch1);
+      archs[1] = libxsmm_get_target_arch();
+    }
+  }
+  return archs[index];
+}
+
+/* returns the target duration of every single benchmark run; if the duration is <= 0 or NaN, no benchmarks will be run */
+double getBenchmarkDuration(){
+  static double duration = -1;
+  if (duration < 0) {
+    duration = 0.1;
+    const char* dur = getenv("BENCHMARK_DURATION");
+    if(dur){
+      duration = atof(dur);
+    }
+  }
+  return duration;
+}
+
+#define BENCHMARK_INIT() \
+  double l_targetRuntimeSeconds = getBenchmarkDuration(); \
+  size_t l_warmupRuns = 1000, l_warmupIndex; \
+  size_t l_benchmarkRuns, l_benchmarkIndex; \
+  double l_warmupDuration, l_duration; \
+  double l_gflops[MAX_BENCHMARK_ARCHITECTURES]; \
+  double l_gbandwidth[MAX_BENCHMARK_ARCHITECTURES]; \
+  const char* l_archNames[MAX_BENCHMARK_ARCHITECTURES]; \
+  const char* l_arch = NULL; \
+  libxsmm_timer_tickint l_startTime0, l_endTime0, l_startTime, l_endTime; /* loop over architectures */ \
+  for (int l_archIndex = 0; l_archIndex < MAX_BENCHMARK_ARCHITECTURES; l_archIndex++) { \
+    if (l_targetRuntimeSeconds > 0){\
+      l_arch = l_archNames[l_archIndex] = getBenchmarkedArch(l_archIndex); \
+      if (!l_arch) break; \
+      libxsmm_finalize(); \
+      libxsmm_init(); \
+      libxsmm_set_target_arch(l_arch);\
+    }
+
+#define BENCHMARK_RUN(BENCHMARKED_CALL, BANDWIDTH_PER_ITERATION, FLOPS_PER_ITERATION) \
+  if (l_targetRuntimeSeconds > 0) { \
+    /* warmup and computation how many steps are required */ \
+    l_startTime0 = libxsmm_timer_tick(); \
+    for (l_warmupIndex = 0; l_warmupIndex < l_warmupRuns; l_warmupIndex++) { \
+      BENCHMARKED_CALL; \
+    } \
+    l_endTime0 = libxsmm_timer_tick(); \
+    l_warmupDuration = libxsmm_timer_duration(l_startTime0, l_endTime0); \
+    if (l_warmupDuration <= 1e-9) l_warmupDuration = 1e-9; \
+    l_benchmarkRuns = (size_t)(l_targetRuntimeSeconds * l_warmupRuns / l_warmupDuration); \
+\
+    /* running the actual benchmark */ \
+    l_startTime = libxsmm_timer_tick(); \
+    for (l_benchmarkIndex = 0; l_benchmarkIndex < l_benchmarkRuns; l_benchmarkIndex++) { \
+      BENCHMARKED_CALL; \
+    } \
+    l_endTime = libxsmm_timer_tick(); \
+    l_duration = libxsmm_timer_duration(l_startTime, l_endTime); \
+    l_gflops[l_archIndex] = FLOPS_PER_ITERATION * (double)l_benchmarkRuns / l_duration * 1e-9; \
+    l_gbandwidth[l_archIndex] = BANDWIDTH_PER_ITERATION * (double)l_benchmarkRuns / l_duration * 1e-9; \
+\
+    /* printing results */ \
+    if (getBenchmarkedArch(1)) printf("Architecture  : %s\n", l_arch); \
+    printf("GB/s Bandwidth: %.24f\n", l_gbandwidth[l_archIndex]); \
+    printf("GFlops        : %.24f\n", l_gflops[l_archIndex]); \
+    printf("Runs          : %ld\n", l_benchmarkRuns); /* how often the kernel was run; could be interesting */ \
+    if (l_archIndex > 0) /* comparison with the first/main architecture */ \
+      printf("Speedup       : %.24fx\n", l_gbandwidth[l_archIndex] / l_gbandwidth[0]); \
+  }
+
+#define BENCHMARK_FINALIZE() \
+  } /* end of loop over architectures */

--- a/samples/eltwise/eltwise_unary_gather_scatter.c
+++ b/samples/eltwise/eltwise_unary_gather_scatter.c
@@ -13,7 +13,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
-#include <immintrin.h>
+
+/* immintrin.h doesn't exist on A64FX; if this file exists for other platforms than X86, adjust this if condition */
+#if defined(LIBXSMM_PLATFORM_X86)
+# include <immintrin.h>
+#endif
 #define COLS 0
 #define ROWS 1
 #define OFFS 2

--- a/samples/eltwise/eltwise_unary_reduce.c
+++ b/samples/eltwise/eltwise_unary_reduce.c
@@ -18,6 +18,9 @@
 #include <immintrin.h>
 #endif
 
+#define TYPE_ADD 0
+#define TYPE_MAX 1
+
 LIBXSMM_INLINE
 void sfill_matrix ( float *matrix, unsigned int ld, unsigned int m, unsigned int n )
 {
@@ -40,8 +43,7 @@ void sfill_matrix ( float *matrix, unsigned int ld, unsigned int m, unsigned int
   }
 }
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   unsigned int m = 64, n = 64, reduce_elts = 1, reduce_elts_squared = 1, reduce_rows = 1, result_size, result_size_check, i, j, jj, k, iters = 10000, reduce_op = 0, use_bf16 = 0;
   unsigned long long n_cols_idx = 0;
   libxsmm_blasint ld_in = 64/*, ld_out = 64*/;
@@ -130,7 +132,7 @@ int main(int argc, char* argv[])
   }
 #endif
 
-  if (reduce_op == 0) {
+  if (reduce_op == TYPE_ADD) {
     /* Calculate reference results...  */
     if (reduce_rows == 1) {
       for (j = 0; j < n; j++) {
@@ -167,7 +169,7 @@ int main(int argc, char* argv[])
         }
       }
     }
-  } else {
+  } else if(reduce_op == TYPE_MAX){
     if (reduce_rows == 1) {
       for (j = 0; j < n; j++) {
         ref_result_reduce_elts[j] = sinp[j*ld_in];
@@ -184,7 +186,7 @@ int main(int argc, char* argv[])
         }
       }
     }
-  }
+  } else { /* should not happen */ }
 
   if (reduce_rows == 1) {
     unary_flags |= LIBXSMM_MELTW_FLAG_UNARY_REDUCE_ROWS;
@@ -192,7 +194,7 @@ int main(int argc, char* argv[])
     unary_flags |= LIBXSMM_MELTW_FLAG_UNARY_REDUCE_COLS;
   }
 
-  if (reduce_op == 0) {
+  if (reduce_op == TYPE_ADD) {
     if ((reduce_elts == 1) && (reduce_elts_squared == 1)) {
       result_reduce_elts_squared = (float*) result_reduce_elts + result_size;
       if (use_bf16 == 1) {
@@ -210,11 +212,11 @@ int main(int argc, char* argv[])
     if ((reduce_elts == 1) && (reduce_elts_squared == 0)) {
       unary_type = LIBXSMM_MELTW_TYPE_UNARY_REDUCE_X_OP_ADD;
     }
-  } else {
+  } else if(reduce_op == TYPE_MAX){
     if ((reduce_elts == 1) && (reduce_elts_squared == 0)) {
       unary_type = LIBXSMM_MELTW_TYPE_UNARY_REDUCE_X_OP_MAX;
     }
-  }
+  } else { /* should not happen */ }
 
   unary_shape.m = m;
   unary_shape.n = n;
@@ -356,7 +358,7 @@ int main(int argc, char* argv[])
   l_start = libxsmm_timer_tick();
   /* Calculate reference results...  */
   for (k = 0; k < iters; k++) {
-    if (reduce_op == 0) {
+    if (reduce_op == TYPE_ADD) {
 
       if (reduce_rows == 1) {
         for (j = 0; j < n; j++) {
@@ -393,7 +395,7 @@ int main(int argc, char* argv[])
         }
       }
 
-    } else {
+    } else if(reduce_op == TYPE_MAX){
       if (reduce_rows == 1) {
         for (j = 0; j < n; j++) {
           ref_result_reduce_elts[j] = sinp[j*ld_in];
@@ -410,7 +412,7 @@ int main(int argc, char* argv[])
           }
         }
       }
-    }
+    } else { /* should not happen */ }
   }
   l_end = libxsmm_timer_tick();
   l_total = libxsmm_timer_duration(l_start, l_end);
@@ -449,7 +451,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  fprintf(stdout, "SUCCESS unnary reduce\n" );
+  fprintf(stdout, "SUCCESS unary reduce\n" );
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
This is the performance tester, that I wrote for SVE (https://github.com/libxsmm/libxsmm/pull/556).

It can compare two target architectures, and will compute the speedup for you: you just have to set your second target architecture in the environment variable "ARCH1".

This PR also includes names for a few enums that just were numbers before, e.g. in eltwise_unary_reduce.c.