### PR TITLE
[batchnorm TPP] Adding scale-only norm type support for batchnorm TPP (and the test driver)

### DIFF
--- a/samples/deeplearning/fusedbn_tpp/layer_example_f32.c
+++ b/samples/deeplearning/fusedbn_tpp/layer_example_f32.c
@@ -176,6 +176,7 @@ int main( int argc, char* argv[] ) {
   printf("##########################################\n");
   printf("PARAMS: N:%d  C:%d  CP:%d bc:%d H:%d W:%d STRIDE:%d (PADDING: must be 0s)\n", N, CP*bc, CP, bc, H, W, stride);
   printf("PARAMS: FUSE TYPE:%d\n", fuse_type);
+  printf("PARAMS: NORM TYPE:%d\n", norm_type);
   printf("PARAMS: ITERS:%d", iters); if (LIBXSMM_FEQ(0, check)) printf("  Threads:%d\n", nThreads); else printf("\n");
   printf("SIZE Input  (MB): %10.2f MiB\n", (double)(N*CP*HW*bc*sizeof(float))/(1024.0*1024.0) );
   printf("SIZE Output (MB): %10.2f MiB\n", (double)(N*CP*HW*bc*sizeof(float))/(1024.0*1024.0) );

--- a/samples/deeplearning/fusedbn_tpp/layer_example_f32.c
+++ b/samples/deeplearning/fusedbn_tpp/layer_example_f32.c
@@ -32,7 +32,8 @@ int main( int argc, char* argv[] ) {
 
   const float eps = FLT_EPSILON;
   libxsmm_blasint i, it;
-  float *inp, *inp_add, *out, *dinp, *dout, *dinp_add, *eqn_dinp, *eqn_dout, *eqn_dinp_add, *dbeta, *eqn_dbeta, *dgamma, *eqn_dgamma, *eqn_out, *gamma, *beta, *cache_fl, *mean, *var, sum = 0.0;
+  float *inp, *inp_add, *out, *dinp, *dout, *dinp_add, *eqn_dinp, *eqn_dout, *eqn_dinp_add, *dbeta, *eqn_dbeta, *dgamma, *eqn_dgamma, *eqn_out, *gamma, *beta, *mean, *var, *eqn_mean, *eqn_var, sum = 0.0;
+  float *cache_fl;
   unsigned char *relumask_uncompressed, *relumask, *eqn_relumask;
   float *naive_inp, *naive_inp_add, *naive_out, *naive_rcpstdev, *naive_dinp, *naive_dout, *naive_dbeta, *naive_dgamma, *naive_dinp_add;
   unsigned char *naive_relumask;
@@ -61,7 +62,7 @@ int main( int argc, char* argv[] ) {
   int pad_w_in  = 0; /* padding mode */
   int pad_h_out = 0; /* padding mode */
   int pad_w_out = 0; /* padding mode */
-  int norm_type = 0; /* 0: full batchnorm, 1: batch scaling only */
+  int norm_type = 0; /* 0: full batchnorm, 1: batch scaling only for fwd / only input gradient for bwd */
   int fuse_type = 5; /* 0: nothing fused, 1: relu fused, 2: ewise fused, 3: relu and ewise fused, 4: relu with mask, 5: relu and ewise with mask  */
 
   int stride_h = 0;  /* defined later */
@@ -112,6 +113,11 @@ int main( int argc, char* argv[] ) {
 
   CP = C / bc;
 
+  if ( C % bc != 0 || CP == 0 ) {
+    printf("Bad input channel blocking: C = %d bc = %d \n", C, bc);
+    return -1;
+  }
+
   /* if H and W are read from cli, redefine HW */
   if (H && W)
     HW = H*W;
@@ -130,8 +136,8 @@ int main( int argc, char* argv[] ) {
     return -1;
   }
 
-  if ( norm_type != 0 ) {
-    printf("Only full batchnorm (norm_type = 0) is supported \n");
+  if ( norm_type != 0 && norm_type != 1) {
+    printf("Only full batchnorm (norm_type = 0) and scale-only (normalize-only for fwd, only input gradient for bwd) norm types are supported \n");
     return -1;
   }
 
@@ -192,6 +198,8 @@ int main( int argc, char* argv[] ) {
   beta       = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   mean       = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   var        = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
+  eqn_mean   = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
+  eqn_var    = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   eqn_out    = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
   cache_fl   = (float*) libxsmm_aligned_malloc( sizeof(float)*1024*1024,   2097152);
 
@@ -250,6 +258,27 @@ int main( int argc, char* argv[] ) {
   init_buf(dgamma,   CP*bc,      1, 0);
   init_buf(dbeta,    CP*bc,      1, 0);
 
+  if (norm_type == 1) { /* normalize-only batchnorm, hence initializing mean and variance */
+    int i;
+    init_buf(mean,   CP*bc,      1, 0);
+    init_buf(var,    CP*bc,      1, 0);
+
+    copy_buf(mean,  eqn_mean, CP*bc);
+    copy_buf(var,   eqn_var,  CP*bc);
+
+    for (i = 0; i < C; i++) {
+      naive_rcpstdev[i] = (float)(1.0/sqrt(var[i] + eps));
+    }
+
+#ifdef COMPUTE_FP64_REFERENCE
+    extend_buf_fp32_to_fp64(mean,   mean_fp64,   CP*bc);
+    extend_buf_fp32_to_fp64(var,    var_fp64,    CP*bc);
+    extend_buf_fp32_to_fp64(dgamma, dgamma_fp64, CP*bc);
+    extend_buf_fp32_to_fp64(dbeta,  dbeta_fp64,  CP*bc);
+    extend_buf_fp32_to_fp64(naive_rcpstdev, naive_rcpstdev_fp64, C);
+#endif
+  }
+
   copy_buf(dout,   eqn_dout,   N*CP*HW*bc);
   copy_buf(dgamma, eqn_dgamma, CP*bc);
   copy_buf(dbeta,  eqn_dbeta,  CP*bc);
@@ -265,8 +294,8 @@ int main( int argc, char* argv[] ) {
 
   /* setup TPPs (standalone or through the configs) */
 
-  my_bn_fwd = setup_my_bn_fwd(N, C, H, W, bc, nThreads, (my_normalization_fuse)fuse_type );
-  my_bn_bwd = setup_my_bn_bwd(N, C, H, W, bc, nThreads, (my_normalization_fuse)fuse_type );
+  my_bn_fwd = setup_my_bn_fwd(N, C, H, W, bc, nThreads, (my_bn_fuse)fuse_type );
+  my_bn_bwd = setup_my_bn_bwd(N, C, H, W, bc, nThreads, (my_bn_fuse)fuse_type );
 
   /* allocate and bind scratch */
   if ( my_bn_fwd.scratch_size > 0 || my_bn_bwd.scratch_size > 0 ) {
@@ -286,7 +315,7 @@ int main( int argc, char* argv[] ) {
 #else
       const int tid = 0;
 #endif
-      my_bn_fwd_exec( my_bn_fwd, inp, inp_add, gamma, beta, mean, var, eqn_out, eqn_relumask, eps, 0, tid, scratch);
+      my_bn_fwd_exec( my_bn_fwd, inp, inp_add, gamma, beta, eqn_mean, eqn_var, eqn_out, eqn_relumask, eps, 0, tid, scratch, (my_bn_norm_type)norm_type );
     }
 
     tensor_copy_NCHWc_to_NCHW (inp,     naive_inp,     N, C, H, W, bc);
@@ -382,7 +411,7 @@ int main( int argc, char* argv[] ) {
 #else
       const int tid = 0;
 #endif
-      my_bn_fwd_exec( my_bn_fwd, inp, inp_add, gamma, beta, mean, var, eqn_out, eqn_relumask, eps, 0, tid, scratch);
+      my_bn_fwd_exec( my_bn_fwd, inp, inp_add, gamma, beta, eqn_mean, eqn_var, eqn_out, eqn_relumask, eps, 0, tid, scratch, (my_bn_norm_type)norm_type );
     }
   l_start = libxsmm_timer_tick();
   for (it = 0; it < iters; it++) {
@@ -395,7 +424,7 @@ int main( int argc, char* argv[] ) {
 #else
       const int tid = 0;
 #endif
-      my_bn_fwd_exec( my_bn_fwd, inp, inp_add, gamma, beta, mean, var, eqn_out, eqn_relumask, eps, 0, tid, scratch );
+      my_bn_fwd_exec( my_bn_fwd, inp, inp_add, gamma, beta, eqn_mean, eqn_var, eqn_out, eqn_relumask, eps, 0, tid, scratch, (my_bn_norm_type)norm_type );
     }
   }
   l_end = libxsmm_timer_tick();
@@ -414,7 +443,7 @@ int main( int argc, char* argv[] ) {
       const int tid = 0;
 #endif
 
-      my_bn_bwd_exec( my_bn_bwd, eqn_dout, inp, mean, var, gamma, relumask, eqn_dinp, eqn_dinp_add, eqn_dgamma, eqn_dbeta, eps, 0, tid, scratch );
+      my_bn_bwd_exec( my_bn_bwd, eqn_dout, inp, mean, var, gamma, relumask, eqn_dinp, eqn_dinp_add, eqn_dgamma, eqn_dbeta, eps, 0, tid, scratch, (my_bn_norm_type)norm_type );
     }
 
     tensor_copy_NCHWc_to_NCHW (inp,  naive_inp,  N, C, H, W, bc);
@@ -577,7 +606,7 @@ int main( int argc, char* argv[] ) {
 #else
       const int tid = 0;
 #endif
-      my_bn_bwd_exec( my_bn_bwd, eqn_dout, inp, mean, var, gamma, relumask, eqn_dinp, eqn_dinp_add, eqn_dgamma, eqn_dbeta, eps, 0, tid, scratch );
+      my_bn_bwd_exec( my_bn_bwd, eqn_dout, inp, mean, var, gamma, relumask, eqn_dinp, eqn_dinp_add, eqn_dgamma, eqn_dbeta, eps, 0, tid, scratch, (my_bn_norm_type)norm_type );
     }
   l_start = libxsmm_timer_tick();
 
@@ -591,7 +620,7 @@ int main( int argc, char* argv[] ) {
 #else
       const int tid = 0;
 #endif
-      my_bn_bwd_exec( my_bn_bwd, eqn_dout, inp, mean, var, gamma, relumask, eqn_dinp, eqn_dinp_add, eqn_dgamma, eqn_dbeta, eps, 0, tid, scratch );
+      my_bn_bwd_exec( my_bn_bwd, eqn_dout, inp, mean, var, gamma, relumask, eqn_dinp, eqn_dinp_add, eqn_dgamma, eqn_dbeta, eps, 0, tid, scratch, (my_bn_norm_type)norm_type );
     }
   }
 
@@ -632,6 +661,8 @@ int main( int argc, char* argv[] ) {
   libxsmm_free(eqn_dbeta);
   libxsmm_free(mean);
   libxsmm_free(var);
+  libxsmm_free(eqn_mean);
+  libxsmm_free(eqn_var);
   libxsmm_free(gamma);
   libxsmm_free(beta);
   libxsmm_free(eqn_out);

--- a/samples/deeplearning/op_lib_tpp/batchnorm_tpp.h
+++ b/samples/deeplearning/op_lib_tpp/batchnorm_tpp.h
@@ -21,14 +21,19 @@
 
 #define BITS_PER_CHAR (8)
 
-typedef enum my_normalization_fuse {
+typedef enum my_bn_fuse {
   MY_BN_FUSE_NONE = 0,
   MY_BN_FUSE_RELU = 1,
   MY_BN_FUSE_ELTWISE = 2,
   MY_BN_FUSE_ELTWISE_RELU = 3,
   MY_BN_FUSE_RELU_WITH_MASK = 4,
   MY_BN_FUSE_ELTWISE_RELU_WITH_MASK = 5
-} my_normalization_fuse;
+} my_bn_fuse;
+
+typedef enum my_bn_norm_type {
+  MY_BN_FULL_NORM  = 0, /* stats + normalize for fwd, all grads for bwd */
+  MY_BN_SCALE_ONLY = 1  /* normalize only for fwd, only input grad for bwd */
+} my_bn_norm_type;
 
 typedef struct my_bn_fwd_config {
   libxsmm_blasint  N;
@@ -50,7 +55,7 @@ typedef struct my_bn_fwd_config {
   libxsmm_meltwfunction_unary  helper_copy_kernel;
   libxsmm_meltwfunction_unary  relu_kernel;
   libxsmm_meltwfunction_binary ewise_add_kernel;
-  my_normalization_fuse        fuse_type;
+  my_bn_fuse        fuse_type;
 } my_bn_fwd_config;
 
 typedef struct my_bn_bwd_config {
@@ -74,11 +79,11 @@ typedef struct my_bn_bwd_config {
   libxsmm_meltwfunction_unary  helper_copy_kernel;
   libxsmm_meltwfunction_unary  inv_relu_kernel;
   libxsmm_meltwfunction_unary  ewise_copy_kernel;
-  my_normalization_fuse        fuse_type;
+  my_bn_fuse        fuse_type;
 } my_bn_bwd_config;
 
 my_bn_fwd_config setup_my_bn_fwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_blasint H, libxsmm_blasint W, libxsmm_blasint bc,
-                                 libxsmm_blasint threads, my_normalization_fuse fuse_type ) {
+                                 libxsmm_blasint threads, my_bn_fuse fuse_type ) {
   my_bn_fwd_config res;
 
   size_t sum_N_offset, sumsq_N_offset;
@@ -275,7 +280,7 @@ my_bn_fwd_config setup_my_bn_fwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_b
 }
 
 my_bn_bwd_config setup_my_bn_bwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_blasint H, libxsmm_blasint W, libxsmm_blasint bc,
-                                 libxsmm_blasint threads, my_normalization_fuse fuse_type ) {
+                                 libxsmm_blasint threads, my_bn_fuse fuse_type ) {
   my_bn_bwd_config res;
 
   libxsmm_meltw_unary_shape  unary_shape;
@@ -594,7 +599,8 @@ void destroy_my_bn_bwd(my_bn_bwd_config* cfg) {
   /* when/if libxsmm_matrix_eqn_destroy gets added, destructords for equations should go here */
 }
 
-void my_bn_fwd_exec( my_bn_fwd_config cfg, const float *pinp, const float *pinp_add, const float *pgamma, const float *pbeta, float *mean, float *var, float *pout, unsigned char *prelumask, float eps, int start_tid, int my_tid, void *scratch ) {
+void my_bn_fwd_exec( my_bn_fwd_config cfg, const float *pinp, const float *pinp_add, const float *pgamma, const float *pbeta, float *mean, float *var, float *pout, unsigned char *prelumask,
+                     float eps, int start_tid, int my_tid, void *scratch, my_bn_norm_type norm_type ) {
 
   const libxsmm_blasint N  = cfg.N;
   const libxsmm_blasint CP = cfg.CP;
@@ -640,28 +646,13 @@ void my_bn_fwd_exec( my_bn_fwd_config cfg, const float *pinp, const float *pinp_
   float alpha = 0.0f;
   LIBXSMM_VLA_DECL(4,       unsigned char, relumask, prelumask, CP, HW, bc/BITS_PER_CHAR);    /* [N, CP, HW, bc/BITS_PER_CHAR] */
 
-  const float scale = 1.0f /((float)N * HW);
-
-  LIBXSMM_VLA_DECL(3, float, sum_X_X2, ((float*)scratch), CP, bc);  /* [2, CP, bc] */
-  LIBXSMM_ASSUME_ALIGNED(sum_X_X2_, 64);
-  const libxsmm_blasint sum_N_offset = (LIBXSMM_UP2((uintptr_t)(((float*)scratch) + CP * 2 * bc), 64) - ((uintptr_t)(scratch))) / sizeof(float);
-  LIBXSMM_VLA_DECL(3, float, sum_N, ((float*)scratch) + sum_N_offset, N, bc);  /* [CP, N, bc] */
-  LIBXSMM_ASSUME_ALIGNED(sum_N_, 64);
-  const libxsmm_blasint sumsq_N_offset = (LIBXSMM_UP2((uintptr_t)(((float*)scratch) + sum_N_offset + CP * N * bc), 64) - ((uintptr_t)(scratch))) / sizeof(float);
-  LIBXSMM_VLA_DECL(3, float, sumsq_N, ((float*)scratch) + sumsq_N_offset, N, bc);  /* [CP, N, bc] */
-  LIBXSMM_ASSUME_ALIGNED(sumsq_N_, 64);
-
-  libxsmm_meltw_unary_param  all_zero_param;
   libxsmm_meltw_binary_param add_param;
-  libxsmm_meltw_unary_param  reduce_HW_param;
   libxsmm_meltw_unary_param  all_relu_param;
 
   libxsmm_matrix_arg arg_array[5];
   libxsmm_matrix_eqn_param eqn_param;
 
-  memset( &all_zero_param,  0, sizeof(all_zero_param));
   memset( &add_param,       0, sizeof(add_param));
-  memset( &reduce_HW_param, 0, sizeof(reduce_HW_param));
   memset( &all_relu_param,  0, sizeof(all_relu_param));
 
   memset( &eqn_param,       0, sizeof(eqn_param));
@@ -671,94 +662,114 @@ void my_bn_fwd_exec( my_bn_fwd_config cfg, const float *pinp, const float *pinp_
   int n, cp;
 
   int cpxnt;
-  for ( cpxnt = thr_begin_dN; cpxnt < thr_end_dN; ++cpxnt ) {
-    n  = cpxnt%N;
-    cp = cpxnt/N;
 
-    int hwb;
+  if (norm_type == MY_BN_FULL_NORM) {
 
-    float *sum_ncp_ptr   = &LIBXSMM_VLA_ACCESS(3, sum_N, cp, n, 0, N, bc);
-    float *sumsq_ncp_ptr = &LIBXSMM_VLA_ACCESS(3, sumsq_N, cp, n, 0, N, bc);
+    const float scale = 1.0f /((float)N * HW);
 
-    all_zero_param.out.primary = sum_ncp_ptr;
-    cfg.all_zero_kernel(&all_zero_param);
-    all_zero_param.out.primary = sumsq_ncp_ptr;
-    cfg.all_zero_kernel(&all_zero_param);
+    LIBXSMM_VLA_DECL(3, float, sum_X_X2, ((float*)scratch), CP, bc);  /* [2, CP, bc] */
+    LIBXSMM_ASSUME_ALIGNED(sum_X_X2_, 64);
+    const libxsmm_blasint sum_N_offset = (LIBXSMM_UP2((uintptr_t)(((float*)scratch) + CP * 2 * bc), 64) - ((uintptr_t)(scratch))) / sizeof(float);
+    LIBXSMM_VLA_DECL(3, float, sum_N, ((float*)scratch) + sum_N_offset, N, bc);  /* [CP, N, bc] */
+    LIBXSMM_ASSUME_ALIGNED(sum_N_, 64);
+    const libxsmm_blasint sumsq_N_offset = (LIBXSMM_UP2((uintptr_t)(((float*)scratch) + sum_N_offset + CP * N * bc), 64) - ((uintptr_t)(scratch))) / sizeof(float);
+    LIBXSMM_VLA_DECL(3, float, sumsq_N, ((float*)scratch) + sumsq_N_offset, N, bc);  /* [CP, N, bc] */
+    LIBXSMM_ASSUME_ALIGNED(sumsq_N_, 64);
 
-    /* #pragma omp simd  */
-    /* for (int cb = 0; cb < bc; cb++) {  */
-    /*   sum_ncp_ptr[cb] = 0.0f;    */
-    /*   sumsq_ncp_ptr[cb] = 0.0f;  */
-    /* } */
+    libxsmm_meltw_unary_param  all_zero_param;
+    libxsmm_meltw_unary_param  reduce_HW_param;
 
+    memset( &all_zero_param,  0, sizeof(all_zero_param));
+    memset( &reduce_HW_param, 0, sizeof(reduce_HW_param));
 
-    LIBXSMM_ALIGNED(float lcl_sum_X_X2[2*bc], 64);
-    reduce_HW_param.out.primary   = lcl_sum_X_X2;                                                         /* [2*bc]  */
-    for(hwb=0; hwb < num_HW_blocks; hwb++){
+    for ( cpxnt = thr_begin_dN; cpxnt < thr_end_dN; ++cpxnt ) {
+      n  = cpxnt%N;
+      cp = cpxnt/N;
 
-      reduce_HW_param.in.primary = (void*)&LIBXSMM_VLA_ACCESS(4, inp, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
-      cfg.reduce_HW_kernel(&reduce_HW_param);                                                       /* [HW, bc] -----> [2 * bc] */
+      int hwb;
 
-      add_param.in0.primary = sum_ncp_ptr;
-      add_param.in1.primary = lcl_sum_X_X2;
-      add_param.out.primary = sum_ncp_ptr;
-      cfg.helper_add_kernel(&add_param);
+      float *sum_ncp_ptr   = &LIBXSMM_VLA_ACCESS(3, sum_N, cp, n, 0, N, bc);
+      float *sumsq_ncp_ptr = &LIBXSMM_VLA_ACCESS(3, sumsq_N, cp, n, 0, N, bc);
 
-      add_param.in0.primary = sumsq_ncp_ptr;
-      add_param.in1.primary = &lcl_sum_X_X2[bc];
-      add_param.out.primary = sumsq_ncp_ptr;
-      cfg.helper_add_kernel(&add_param);
+      all_zero_param.out.primary = sum_ncp_ptr;
+      cfg.all_zero_kernel(&all_zero_param);
+      all_zero_param.out.primary = sumsq_ncp_ptr;
+      cfg.all_zero_kernel(&all_zero_param);
+
+      /* #pragma omp simd  */
+      /* for (int cb = 0; cb < bc; cb++) {  */
+      /*   sum_ncp_ptr[cb] = 0.0f;    */
+      /*   sumsq_ncp_ptr[cb] = 0.0f;  */
+      /* } */
+
+      LIBXSMM_ALIGNED(float lcl_sum_X_X2[2*bc], 64);
+      reduce_HW_param.out.primary   = lcl_sum_X_X2;                                                         /* [2*bc]  */
+      for(hwb=0; hwb < num_HW_blocks; hwb++){
+
+        reduce_HW_param.in.primary = (void*)&LIBXSMM_VLA_ACCESS(4, inp, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
+        cfg.reduce_HW_kernel(&reduce_HW_param);                                                       /* [HW, bc] -----> [2 * bc] */
+
+        add_param.in0.primary = sum_ncp_ptr;
+        add_param.in1.primary = lcl_sum_X_X2;
+        add_param.out.primary = sum_ncp_ptr;
+        cfg.helper_add_kernel(&add_param);
+
+        add_param.in0.primary = sumsq_ncp_ptr;
+        add_param.in1.primary = &lcl_sum_X_X2[bc];
+        add_param.out.primary = sumsq_ncp_ptr;
+        cfg.helper_add_kernel(&add_param);
+
+        /* #pragma omp simd */
+        /* for (int cb = 0; cb < bc; cb++) {  */
+        /*   sum_ncp_ptr[cb] += lcl_sum_X_X2[cb];  */
+        /*   sumsq_ncp_ptr[cb] += lcl_sum_X_X2[bc + cb];  */
+        /* }  */
+      }
+    }
+
+    libxsmm_barrier_wait(cfg.barrier, ltid);
+
+    for ( cp = thr_begin_C; cp < thr_end_C; ++cp ) {
+
+      all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, 0, CP, bc);
+      cfg.all_zero_kernel(&all_zero_param);
+      all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, 0, CP, bc);
+      cfg.all_zero_kernel(&all_zero_param);
 
       /* #pragma omp simd */
       /* for (int cb = 0; cb < bc; cb++) {  */
-      /*   sum_ncp_ptr[cb] += lcl_sum_X_X2[cb];  */
-      /*   sumsq_ncp_ptr[cb] += lcl_sum_X_X2[bc + cb];  */
-      /* }  */
-    }
-  }
-
-  libxsmm_barrier_wait(cfg.barrier, ltid);
-
-  for ( cp = thr_begin_C; cp < thr_end_C; ++cp ) {
-
-    all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, 0, CP, bc);
-    cfg.all_zero_kernel(&all_zero_param);
-    all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, 0, CP, bc);
-    cfg.all_zero_kernel(&all_zero_param);
-
-    /* #pragma omp simd */
-    /* for (int cb = 0; cb < bc; cb++) {  */
-    /*   sum_X_X2[cp*bc + cb] = 0.0f;   */
-    /*   sum_X_X2[CP*bc + (cp*bc + cb)] = 0.0f;  */
-    /* } */
-
-    int cb, ni;
-    for(ni = 0; ni < N; ni++){
-
-      add_param.in0.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, 0, CP, bc);
-      add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, sum_N, cp, ni, 0, N, bc);
-      add_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, 0, CP, bc);
-      cfg.helper_add_kernel(&add_param);
-
-      add_param.in0.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, 0, CP, bc);
-      add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, sumsq_N, cp, ni, 0, N, bc);
-      add_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, 0, CP, bc);
-      cfg.helper_add_kernel(&add_param);
-
-      /* #pragma omp simd */
-      /* for (int cb = 0; cb < bc; cb++) { */
-      /*   sum_X_X2[cp*bc + cb] += sum_N[cp*N*bc + n*bc + cb]; */
-      /*   sum_X_X2[CP*bc + (cp*bc + cb)] += sumsq_N[cp*N*bc + n*bc + cb]; */
+      /*   sum_X_X2[cp*bc + cb] = 0.0f;   */
+      /*   sum_X_X2[CP*bc + (cp*bc + cb)] = 0.0f;  */
       /* } */
+
+      int cb, ni;
+      for(ni = 0; ni < N; ni++){
+
+        add_param.in0.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, 0, CP, bc);
+        add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, sum_N, cp, ni, 0, N, bc);
+        add_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, 0, CP, bc);
+        cfg.helper_add_kernel(&add_param);
+
+        add_param.in0.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, 0, CP, bc);
+        add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, sumsq_N, cp, ni, 0, N, bc);
+        add_param.out.primary = &LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, 0, CP, bc);
+        cfg.helper_add_kernel(&add_param);
+
+        /* #pragma omp simd */
+        /* for (int cb = 0; cb < bc; cb++) { */
+        /*   sum_X_X2[cp*bc + cb] += sum_N[cp*N*bc + n*bc + cb]; */
+        /*   sum_X_X2[CP*bc + (cp*bc + cb)] += sumsq_N[cp*N*bc + n*bc + cb]; */
+        /* } */
+      }
+
+      for(cb = 0; cb < bc; cb++){
+        mean[cp*bc + cb] = (LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, cb, CP, bc)) * scale;                 /* E[X] */
+        var[cp*bc + cb] = ((LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, cb, CP, bc)) * scale) - (mean[cp*bc + cb]*mean[cp*bc + cb]);
+      }
     }
 
-    for(cb = 0; cb < bc; cb++){
-      mean[cp*bc + cb] = (LIBXSMM_VLA_ACCESS(3, sum_X_X2, 0, cp, cb, CP, bc)) * scale;                 /* E[X] */
-      var[cp*bc + cb] = ((LIBXSMM_VLA_ACCESS(3, sum_X_X2, 1, cp, cb, CP, bc)) * scale) - (mean[cp*bc + cb]*mean[cp*bc + cb]);
-    }
-  }
-
-  libxsmm_barrier_wait(cfg.barrier, ltid);
+    libxsmm_barrier_wait(cfg.barrier, ltid);
+  } /* mean and var computation are for the full norm only */
 
   for ( cpxnt = thr_begin_dN; cpxnt < thr_end_dN; ++cpxnt ) {
     n  = cpxnt%N;
@@ -814,7 +825,7 @@ void my_bn_fwd_exec( my_bn_fwd_config cfg, const float *pinp, const float *pinp_
 
 void my_bn_bwd_exec( my_bn_bwd_config cfg, float *pdout, const float *pinp, const float *mean, const float *var, const float *pgamma, const unsigned char *prelumask,
                      float *pdin, float *pdin_add, float *pdgamma, float *pdbeta, float eps,
-                     int start_tid, int my_tid, void *scratch) {
+                     int start_tid, int my_tid, void *scratch, my_bn_norm_type norm_type) {
 
   const libxsmm_blasint N  = cfg.N;
   const libxsmm_blasint CP = cfg.CP;
@@ -891,130 +902,133 @@ void my_bn_bwd_exec( my_bn_bwd_config cfg, float *pdout, const float *pinp, cons
   LIBXSMM_ALIGNED(float a[bc], 64); /* could also get moved into the scratch but left on the private stack as these are small, same below */
   LIBXSMM_ALIGNED(float b[bc], 64);
   LIBXSMM_ALIGNED(float c[bc], 64);
-  int n, cp;
 
   int cpxnt;
+  int n, cp;
 
-  for ( cpxnt = thr_begin_dN; cpxnt < thr_end_dN; ++cpxnt ) {
-    n  = cpxnt%N;
-    cp = cpxnt/N;
+  if (norm_type == MY_BN_FULL_NORM) {
+    for ( cpxnt = thr_begin_dN; cpxnt < thr_end_dN; ++cpxnt ) {
+      n  = cpxnt%N;
+      cp = cpxnt/N;
 
-    int hwb, cb;
+      int hwb, cb;
 
-    LIBXSMM_ALIGNED(float lcl_dgamma_ptr[bc], 64);
-    LIBXSMM_ALIGNED(float lcl_dbeta_ptr[bc], 64);
+      LIBXSMM_ALIGNED(float lcl_dgamma_ptr[bc], 64);
+      LIBXSMM_ALIGNED(float lcl_dbeta_ptr[bc], 64);
 
-    float *dgamma_ncp_ptr = &LIBXSMM_VLA_ACCESS(3, dgamma_N, cp, n, 0, N, bc);
-    float *dbeta_ncp_ptr  = &LIBXSMM_VLA_ACCESS(3, dbeta_N, cp, n, 0, N, bc);
+      float *dgamma_ncp_ptr = &LIBXSMM_VLA_ACCESS(3, dgamma_N, cp, n, 0, N, bc);
+      float *dbeta_ncp_ptr  = &LIBXSMM_VLA_ACCESS(3, dbeta_N, cp, n, 0, N, bc);
 
-    all_zero_param.out.primary = lcl_dgamma_ptr;
-    cfg.all_zero_kernel(&all_zero_param);
-    all_zero_param.out.primary = lcl_dbeta_ptr;
-    cfg.all_zero_kernel(&all_zero_param);
-
-    /* #pragma omp simd */
-    /* for (int cb = 0; cb < bc; cb++) { */
-    /*   lcl_dgamma_ptr[cb] = 0.0f; */
-    /*   lcl_dbeta_ptr[cb] = 0.0f; */
-    /* } */
-
-    for(cb = 0; cb < bc; cb++){
-      float lvar   = LIBXSMM_VLA_ACCESS(2, var,   cp, cb, bc);
-      float lmean  = LIBXSMM_VLA_ACCESS(2, mean,  cp, cb, bc);
-
-      a[cb] = 1.0f / ((float)sqrt(lvar + eps));
-      b[cb] = -a[cb] * lmean;
-
-      /* a[cb] = 1.0f / ((float)sqrt(var[cp*bc + cb] + eps)); */
-      /* b[cb] = -a[cb]*mean[cp*bc + cb];                     */
-    }
-
-    arg_array[1].primary = a;
-    arg_array[2].primary = b;
-    arg_array[4].primary = lcl_dgamma_ptr;
-    arg_array[5].primary = lcl_dbeta_ptr;
-    arg_array[6].primary = (void*)&LIBXSMM_VLA_ACCESS(2, gamma, cp, 0, bc);
-
-    for(hwb=0; hwb < num_HW_blocks; hwb++){
-      if (cfg.fuse_type == MY_BN_FUSE_ELTWISE ||
-        cfg.fuse_type == MY_BN_FUSE_RELU || cfg.fuse_type == MY_BN_FUSE_RELU_WITH_MASK || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) {
-        if (cfg.fuse_type == MY_BN_FUSE_RELU || cfg.fuse_type == MY_BN_FUSE_RELU_WITH_MASK || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) {
-          all_relu_param.op.primary   = (void*)(&alpha);
-          all_relu_param.in.primary   = &LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);      /* [HW,bc] */
-          all_relu_param.in.secondary = ((cfg.fuse_type == MY_BN_FUSE_RELU_WITH_MASK || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) ?
-                                           (void*)&LIBXSMM_VLA_ACCESS(4, relumask, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc/8)
-                                           : NULL /*&LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc) */ ); /* dout_fwd ? nonsense? */
-          all_relu_param.out.primary  = &LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);      /* [HW,bc] */
-          cfg.inv_relu_kernel(&all_relu_param);
-        } /* ReLU/mask */
-        if (cfg.fuse_type == MY_BN_FUSE_ELTWISE || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) {
-          ewise_copy_param.in.primary  = &LIBXSMM_VLA_ACCESS(4, dout,    n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
-          ewise_copy_param.out.primary = &LIBXSMM_VLA_ACCESS(4, din_add, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
-          cfg.ewise_copy_kernel(&ewise_copy_param);
-        } /* Eltwise */
-      }
-      arg_array[0].primary = (void*)&LIBXSMM_VLA_ACCESS(4, inp, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
-      arg_array[3].primary = (void*)&LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
-
-      eqn_param.inputs = arg_array;
-      eqn_param.output.primary = lcl_dgamma_ptr;
-      cfg.dgamma_func(&eqn_param);                                                             /* dgamma += (a * inp + b) * dout */
-
-      eqn_param.output.primary = lcl_dbeta_ptr;
-      cfg.dbeta_func(&eqn_param);                                                              /* dbeta += dout */
-    }
-
-    copy_param.in.primary = lcl_dgamma_ptr;
-    copy_param.out.primary = dgamma_ncp_ptr;
-    cfg.helper_copy_kernel(&copy_param);
-
-    copy_param.in.primary = lcl_dbeta_ptr;
-    copy_param.out.primary = dbeta_ncp_ptr;
-    cfg.helper_copy_kernel(&copy_param);
-
-    /* #pragma omp simd */
-    /* for (int cb = 0; cb < bc; cb++) { */
-    /*   dgamma_ncp_ptr[cb] = lcl_dgamma_ptr[cb]; */
-    /*   dbeta_ncp_ptr[cb] = lcl_dbeta_ptr[cb]; */
-    /* } */
-  }
-
-  libxsmm_barrier_wait(cfg.barrier, ltid);
-
-  for ( cp = thr_begin_C; cp < thr_end_C; ++cp ) {
-    all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dgamma, cp, 0, bc);
-    cfg.all_zero_kernel(&all_zero_param);
-    all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dbeta, cp, 0, bc);
-    cfg.all_zero_kernel(&all_zero_param);
-
-    /* #pragma omp simd */
-    /* for (int cb = 0; cb < bc; cb++) { */
-    /*   pdgamma[cp*bc + cb] = 0.0f; */
-    /*   pdbeta[cp*bc + cb] = 0.0f; */
-    /* } */
-
-    int ni;
-    for(ni = 0; ni < N; ni++){
-
-      add_param.in0.primary = &LIBXSMM_VLA_ACCESS(2, dgamma, cp, 0, bc);
-      add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, dgamma_N, cp, ni, 0, N, bc);
-      add_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dgamma, cp, 0, bc);
-      cfg.helper_add_kernel(&add_param);
-
-      add_param.in0.primary = &LIBXSMM_VLA_ACCESS(2, dbeta, cp, 0, bc);
-      add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, dbeta_N, cp, ni, 0, N, bc);
-      add_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dbeta, cp, 0, bc);
-      cfg.helper_add_kernel(&add_param);
+      all_zero_param.out.primary = lcl_dgamma_ptr;
+      cfg.all_zero_kernel(&all_zero_param);
+      all_zero_param.out.primary = lcl_dbeta_ptr;
+      cfg.all_zero_kernel(&all_zero_param);
 
       /* #pragma omp simd */
       /* for (int cb = 0; cb < bc; cb++) { */
-      /*   pdgamma[cp*bc + cb] += dgamma_N[cp*N*bc + n*bc + cb];  */
-      /*   pdbeta[cp*bc + cb] += dbeta_N[cp*N*bc + n*bc + cb];  */
+      /*   lcl_dgamma_ptr[cb] = 0.0f; */
+      /*   lcl_dbeta_ptr[cb] = 0.0f; */
+      /* } */
+
+      for(cb = 0; cb < bc; cb++){
+        float lvar   = LIBXSMM_VLA_ACCESS(2, var,   cp, cb, bc);
+        float lmean  = LIBXSMM_VLA_ACCESS(2, mean,  cp, cb, bc);
+
+        a[cb] = 1.0f / ((float)sqrt(lvar + eps));
+        b[cb] = -a[cb] * lmean;
+
+        /* a[cb] = 1.0f / ((float)sqrt(var[cp*bc + cb] + eps)); */
+        /* b[cb] = -a[cb]*mean[cp*bc + cb];                     */
+      }
+
+      arg_array[1].primary = a;
+      arg_array[2].primary = b;
+      arg_array[4].primary = lcl_dgamma_ptr;
+      arg_array[5].primary = lcl_dbeta_ptr;
+      arg_array[6].primary = (void*)&LIBXSMM_VLA_ACCESS(2, gamma, cp, 0, bc);
+
+      for(hwb=0; hwb < num_HW_blocks; hwb++){
+        if (cfg.fuse_type == MY_BN_FUSE_ELTWISE ||
+          cfg.fuse_type == MY_BN_FUSE_RELU || cfg.fuse_type == MY_BN_FUSE_RELU_WITH_MASK || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) {
+          if (cfg.fuse_type == MY_BN_FUSE_RELU || cfg.fuse_type == MY_BN_FUSE_RELU_WITH_MASK || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) {
+            all_relu_param.op.primary   = (void*)(&alpha);
+            all_relu_param.in.primary   = &LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);      /* [HW,bc] */
+            all_relu_param.in.secondary = ((cfg.fuse_type == MY_BN_FUSE_RELU_WITH_MASK || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) ?
+                                             (void*)&LIBXSMM_VLA_ACCESS(4, relumask, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc/8)
+                                             : NULL /*&LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc) */ ); /* dout_fwd ? nonsense? */
+            all_relu_param.out.primary  = &LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);      /* [HW,bc] */
+            cfg.inv_relu_kernel(&all_relu_param);
+          } /* ReLU/mask */
+          if (cfg.fuse_type == MY_BN_FUSE_ELTWISE || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU || cfg.fuse_type == MY_BN_FUSE_ELTWISE_RELU_WITH_MASK) {
+            ewise_copy_param.in.primary  = &LIBXSMM_VLA_ACCESS(4, dout,    n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
+            ewise_copy_param.out.primary = &LIBXSMM_VLA_ACCESS(4, din_add, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
+            cfg.ewise_copy_kernel(&ewise_copy_param);
+          } /* Eltwise */
+        }
+        arg_array[0].primary = (void*)&LIBXSMM_VLA_ACCESS(4, inp, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
+        arg_array[3].primary = (void*)&LIBXSMM_VLA_ACCESS(4, dout, n, cp, hwb*(HW/num_HW_blocks), 0, CP, HW, bc);
+
+        eqn_param.inputs = arg_array;
+        eqn_param.output.primary = lcl_dgamma_ptr;
+        cfg.dgamma_func(&eqn_param);                                                             /* dgamma += (a * inp + b) * dout */
+
+        eqn_param.output.primary = lcl_dbeta_ptr;
+        cfg.dbeta_func(&eqn_param);                                                              /* dbeta += dout */
+      }
+
+      copy_param.in.primary = lcl_dgamma_ptr;
+      copy_param.out.primary = dgamma_ncp_ptr;
+      cfg.helper_copy_kernel(&copy_param);
+
+      copy_param.in.primary = lcl_dbeta_ptr;
+      copy_param.out.primary = dbeta_ncp_ptr;
+      cfg.helper_copy_kernel(&copy_param);
+
+      /* #pragma omp simd */
+      /* for (int cb = 0; cb < bc; cb++) { */
+      /*   dgamma_ncp_ptr[cb] = lcl_dgamma_ptr[cb]; */
+      /*   dbeta_ncp_ptr[cb] = lcl_dbeta_ptr[cb]; */
       /* } */
     }
-  }
 
-  libxsmm_barrier_wait(cfg.barrier, ltid);
+    libxsmm_barrier_wait(cfg.barrier, ltid);
+
+    for ( cp = thr_begin_C; cp < thr_end_C; ++cp ) {
+      all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dgamma, cp, 0, bc);
+      cfg.all_zero_kernel(&all_zero_param);
+      all_zero_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dbeta, cp, 0, bc);
+      cfg.all_zero_kernel(&all_zero_param);
+
+      /* #pragma omp simd */
+      /* for (int cb = 0; cb < bc; cb++) { */
+      /*   pdgamma[cp*bc + cb] = 0.0f; */
+      /*   pdbeta[cp*bc + cb] = 0.0f; */
+      /* } */
+
+      int ni;
+      for(ni = 0; ni < N; ni++){
+
+        add_param.in0.primary = &LIBXSMM_VLA_ACCESS(2, dgamma, cp, 0, bc);
+        add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, dgamma_N, cp, ni, 0, N, bc);
+        add_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dgamma, cp, 0, bc);
+        cfg.helper_add_kernel(&add_param);
+
+        add_param.in0.primary = &LIBXSMM_VLA_ACCESS(2, dbeta, cp, 0, bc);
+        add_param.in1.primary = &LIBXSMM_VLA_ACCESS(3, dbeta_N, cp, ni, 0, N, bc);
+        add_param.out.primary = &LIBXSMM_VLA_ACCESS(2, dbeta, cp, 0, bc);
+        cfg.helper_add_kernel(&add_param);
+
+        /* #pragma omp simd */
+        /* for (int cb = 0; cb < bc; cb++) { */
+        /*   pdgamma[cp*bc + cb] += dgamma_N[cp*N*bc + n*bc + cb];  */
+        /*   pdbeta[cp*bc + cb] += dbeta_N[cp*N*bc + n*bc + cb];  */
+        /* } */
+      }
+    }
+
+    libxsmm_barrier_wait(cfg.barrier, ltid);
+
+  } /* this is only computed in case of full backward (norm_type ~ 0) */
 
   for ( cpxnt = thr_begin_dN; cpxnt < thr_end_dN; ++cpxnt ) {
     n  = cpxnt%N;

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dnn_refactor-1.17-2211
+dev/kvoronin/batchnorm_nostats_extension-1.17-2212

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_nostats_extension-1.17-2212
+dev/kvoronin/batchnorm_nostats_extension-1.17-2213


### PR DESCRIPTION
Summary:

- Adding `norm_type` to batchnorm TPP and the driver in samples/deeplearning/fusedbn_tpp
- Renaming enum for fuse type to be consistent with the groupnorm
- Minor changes in the driver

Tested locally with `norm_type = 0, 1`, both work (compared to naive implementation in dnn_common.h).


