### PR TITLE
Removed the redundant and too strict a check for datatypes for the gemm generator

### DIFF
--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -149,28 +149,14 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
 
   /* in case when A needs to be transposed, we need to change temporarily the desciptor dimensions for gemm */
   lda_transpose = i_xgemm_desc->m;
-  if (LIBXSMM_DATATYPE_F32 == (libxsmm_datatype)(i_xgemm_desc->datatype)) {
-    l_xgemm_desc_opa = (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A ?
-      libxsmm_sgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
-        lda_transpose,
-        i_xgemm_desc->ldb,
-        i_xgemm_desc->ldc,
-        1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
-        (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch)
-      : i_xgemm_desc);
-  } else if (LIBXSMM_DATATYPE_F64 == (libxsmm_datatype)(i_xgemm_desc->datatype)) {
-    l_xgemm_desc_opa = (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A ?
-      libxsmm_dgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
-        lda_transpose,
-        i_xgemm_desc->ldb,
-        i_xgemm_desc->ldc,
-        1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
-        (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch)
-      : i_xgemm_desc);
-  } else {
-    LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
-    return;
-  }
+  l_xgemm_desc_opa = (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A ?
+    libxsmm_sgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
+      lda_transpose,
+      i_xgemm_desc->ldb,
+      i_xgemm_desc->ldc,
+      1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
+      (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch)
+    : i_xgemm_desc);
 
   /* define the micro kernel code gen properties */
   libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, l_xgemm_desc_opa, 0 );

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -149,6 +149,29 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
 
   /* in case when A needs to be transposed, we need to change temporarily the desciptor dimensions for gemm */
   lda_transpose = i_xgemm_desc->m;
+  if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) {
+    if (LIBXSMM_DATATYPE_F32 == (libxsmm_datatype)(i_xgemm_desc->datatype))
+      l_xgemm_desc_opa = libxsmm_sgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
+        lda_transpose,
+        i_xgemm_desc->ldb,
+        i_xgemm_desc->ldc,
+        1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
+        (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch);
+    else if (LIBXSMM_DATATYPE_F64 == (libxsmm_datatype)(i_xgemm_desc->datatype))
+      l_xgemm_desc_opa = libxsmm_dgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
+        lda_transpose,
+        i_xgemm_desc->ldb,
+        i_xgemm_desc->ldc,
+        1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
+        (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch);
+    else {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
+      return;
+    }
+  } else {
+    l_xgemm_desc_opa = i_xgemm_desc;
+  }
+
   l_xgemm_desc_opa = (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A ?
     libxsmm_sgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
       lda_transpose,

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -172,15 +172,6 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     l_xgemm_desc_opa = i_xgemm_desc;
   }
 
-  l_xgemm_desc_opa = (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A ?
-    libxsmm_sgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
-      lda_transpose,
-      i_xgemm_desc->ldb,
-      i_xgemm_desc->ldc,
-      1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
-      (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch)
-    : i_xgemm_desc);
-
   /* define the micro kernel code gen properties */
   libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, l_xgemm_desc_opa, 0 );
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-a_transpose-1.17-2253
+dev/kvoronin/a_transpose_dtype_check_fix-1.17-2254

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-a_transpose-1.17-2210
+a_transpose-1.17-2253

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/a_transpose_dtype_check_fix-1.17-2254
+dev/kvoronin/a_transpose_dtype_check_fix-1.17-2255


### PR DESCRIPTION
Summary:
Optional creation of a modified gemm descriptor (due to the optional presence of A transpose flag) had an extra check for the datatype and disallowed bf16. Now this extra check is removed.


