### PR TITLE
Extending batchnorm to support physical padding for input and output

### DIFF
--- a/samples/deeplearning/libxsmm_dnn/include/dnn_common.h
+++ b/samples/deeplearning/libxsmm_dnn/include/dnn_common.h
@@ -45,6 +45,10 @@ typedef struct {
   int C;
   int H;
   int W;
+  int pad_h_in;
+  int pad_w_in;
+  int pad_h_out;
+  int pad_w_out;
   int stride_h;
   int stride_w;
   int norm_type;  /* 0: full batchnorm, 1: batch scaling only */
@@ -2672,20 +2676,34 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_fp(naive_fusedbatchnorm_t* param, const
   const int nFm = param->C;
   const int ifh = param->H;
   const int ifw = param->W;
+  const int ifhp = param->H + 2 * param->pad_h_in;
+  const int ifwp = param->W + 2 * param->pad_w_in;
+  const int hi_start = param->pad_h_in;
+  const int wi_start = param->pad_w_in;
+  const int hi_end = param->pad_h_in + param->H;
+  const int wi_end = param->pad_w_in + param->W;
   const int sh = param->stride_h;
   const int sw = param->stride_w;
+  /*
   const int ofh = ifh/sh;
   const int ofw = ifw/sw;
+  */
+  const int ofhp = param->H + 2 * param->pad_h_out;
+  const int ofwp = param->W + 2 * param->pad_w_out;
+  const int ho_start = param->pad_h_out;
+  const int wo_start = param->pad_w_out;
+  const int ho_end = param->pad_h_out + param->H;
+  const int wo_end = param->pad_w_out + param->W;
   const float nhw = (float)(nImg * ifh * ifw);
   const float recp_nhw = 1.0f/nhw;
 
   int img, fm, hi, wi, ho, wo;
 
-  LIBXSMM_VLA_DECL(4, const float,   input,     input_ptr,     nFm, ifh, ifw);
-  LIBXSMM_VLA_DECL(4, const float,   input_add, input_add_ptr, nFm, ifh, ifw);
-  LIBXSMM_VLA_DECL(4,       float,   output,    output_ptr,    nFm, ofh, ofw);
+  LIBXSMM_VLA_DECL(4, const float,   input,     input_ptr,     nFm, ifhp, ifwp);
+  LIBXSMM_VLA_DECL(4, const float,   input_add, input_add_ptr, nFm, ifhp, ifwp);
+  LIBXSMM_VLA_DECL(4,       float,   output,    output_ptr,    nFm, ofhp, ofwp);
 
-  LIBXSMM_VLA_DECL(4, unsigned char, relumask,  relumask_ptr,  nFm, ofh, ofw); /* no compression, 1 char per entry (only 1 bit used) */
+  LIBXSMM_VLA_DECL(4, unsigned char, relumask,  relumask_ptr,  nFm, ofhp, ofwp); /* no compression, 1 char per entry (only 1 bit used) */
 
   if ( param->norm_type == 0 ) {
 #if defined(_OPENMP)
@@ -2702,9 +2720,9 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_fp(naive_fusedbatchnorm_t* param, const
       float tvariance = 0.0f;
 
       for ( img = 0; img < nImg; img++ ) {
-        for ( hi = 0; hi < ifh; hi++ ) {
-          for ( wi = 0; wi < ifw; wi++ ) {
-            const float input_val = LIBXSMM_VLA_ACCESS(4, input, img, fm, hi, wi, nFm, ifh, ifw);
+        for ( hi = hi_start; hi < hi_start + ifh; hi++ ) {
+          for ( wi = wi_start; wi < wi_start + ifw; wi++ ) {
+            const float input_val = LIBXSMM_VLA_ACCESS(4, input, img, fm, hi, wi, nFm, ifhp, ifwp);
             ch_sum   += input_val;
             ch_sumsq += (input_val * input_val);
           }
@@ -2728,17 +2746,36 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_fp(naive_fusedbatchnorm_t* param, const
 #endif
   for ( img = 0; img < nImg; img++ ) {
     for ( fm = 0; fm < nFm; fm++ ) {
-      for ( hi = 0, ho = 0; hi < ifh; hi += sh, ho++ ) {
-        for ( wi = 0, wo = 0; wi < ifw; wi += sw, wo++ ) {
-          const float  input_val     =  LIBXSMM_VLA_ACCESS(4, input,     img, fm, hi, wi, nFm, ifh, ifw);
+      /* Handling the padding at the start */
+      for (ho = 0; ho < ho_start; ho++) {
+        for (wo = 0; wo < ofwp; wo++) {
+          float* output_ptr2   = &LIBXSMM_VLA_ACCESS(4, output,    img, fm, ho, wo, nFm, ofhp, ofwp);
+          *output_ptr2 = 0;
+          unsigned char* relumask_ptr2 = &LIBXSMM_VLA_ACCESS(4, relumask, img, fm, ho, wo, nFm, ofhp, ofwp);
+          *relumask_ptr2 = 0;
+        }
+      }
+      for (wo = 0; wo < wo_start; wo++) {
+        for (ho = 0; ho < ofhp; ho++) {
+          float* output_ptr2   = &LIBXSMM_VLA_ACCESS(4, output,    img, fm, ho, wo, nFm, ofhp, ofwp);
+          *output_ptr2 = 0;
+          unsigned char* relumask_ptr2 = &LIBXSMM_VLA_ACCESS(4, relumask, img, fm, ho, wo, nFm, ofhp, ofwp);
+          *relumask_ptr2 = 0;
+        }
+      }
+
+      /* Computing the actual batchnorm for the middle (internal) part */
+      for ( hi = hi_start, ho = ho_start; hi < hi_end; hi += sh, ho++ ) {
+        for ( wi = wi_start, wo = wo_start; wi < wi_end; wi += sw, wo++ ) {
+          const float  input_val     =  LIBXSMM_VLA_ACCESS(4, input,     img, fm, hi, wi, nFm, ifhp, ifwp);
           /*const float  input_add_val =  LIBXSMM_VLA_ACCESS(4, input_add, img, fm, hi, wi, nFm, ifh, ifw);*/
-                float* output_ptr2   = &LIBXSMM_VLA_ACCESS(4, output,    img, fm, ho, wo, nFm, ofh, ofw);
+                float* output_ptr2   = &LIBXSMM_VLA_ACCESS(4, output,    img, fm, ho, wo, nFm, ofhp, ofwp);
 
           /* BN + scale (gamma, beta) */
           float o = gamma_ptr[fm]*(input_val - expectval_ptr[fm])*rcpstddev_ptr[fm] + beta_ptr[fm];
           /* Eltwise */
           if ( (param->fuse_type == 2) || (param->fuse_type == 3) || (param->fuse_type == 5) ) {
-            const float input_add_val = LIBXSMM_VLA_ACCESS(4, input_add, img, fm, hi, wi, nFm, ifh, ifw);
+            const float input_add_val = LIBXSMM_VLA_ACCESS(4, input_add, img, fm, hi, wi, nFm, ifhp, ifwp);
             o += input_add_val;
           }
           /* ReLU */
@@ -2750,11 +2787,30 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_fp(naive_fusedbatchnorm_t* param, const
           if ( (param->fuse_type == 4) || (param->fuse_type == 5) ) {
 
             /* without compression */
-            unsigned char* relumask_ptr2 = &LIBXSMM_VLA_ACCESS(4, relumask, img, fm, ho, wo, nFm, ofh, ofw);
+            unsigned char* relumask_ptr2 = &LIBXSMM_VLA_ACCESS(4, relumask, img, fm, ho, wo, nFm, ofhp, ofwp);
             *relumask_ptr2 = (unsigned char)(( o <= 0.0f ) ? 0x0 : 1/*(1 << (i%8))*/ );
           }
         }
       }
+
+      /* Handling the padding at the end */
+      for (ho = ho_end; ho < ofhp; ho++) {
+        for (wo = 0; wo < ofwp; wo++) {
+          float* output_ptr2   = &LIBXSMM_VLA_ACCESS(4, output,    img, fm, ho, wo, nFm, ofhp, ofwp);
+          *output_ptr2 = 0;
+          unsigned char* relumask_ptr2 = &LIBXSMM_VLA_ACCESS(4, relumask, img, fm, ho, wo, nFm, ofhp, ofwp);
+          *relumask_ptr2 = 0;
+        }
+      }
+      for (wo = wo_end; wo < ofwp; wo++) {
+        for (ho = 0; ho < ofhp; ho++) {
+          float* output_ptr2   = &LIBXSMM_VLA_ACCESS(4, output,    img, fm, ho, wo, nFm, ofhp, ofwp);
+          *output_ptr2 = 0;
+          unsigned char* relumask_ptr2 = &LIBXSMM_VLA_ACCESS(4, relumask, img, fm, ho, wo, nFm, ofhp, ofwp);
+          *relumask_ptr2 = 0;
+        }
+      }
+
     }
   }
 }
@@ -2862,20 +2918,34 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
   const int nFm = param->C;
   const int ifh = param->H;
   const int ifw = param->W;
+  const int ifhp = param->H + 2 * param->pad_h_in;
+  const int ifwp = param->W + 2 * param->pad_w_in;
+  const int hi_start = param->pad_h_in;
+  const int wi_start = param->pad_w_in;
+  const int hi_end = param->pad_h_in + param->H;
+  const int wi_end = param->pad_w_in + param->W;
   const int sh = param->stride_h;
   const int sw = param->stride_w;
+  /*
   const int ofh = ifh/sh;
   const int ofw = ifw/sw;
+  */
+  const int ofhp = param->H + 2 * param->pad_h_out;
+  const int ofwp = param->W + 2 * param->pad_w_out;
+  const int ho_start = param->pad_h_out;
+  const int wo_start = param->pad_w_out;
+  const int ho_end = param->pad_h_out + param->H;
+  const int wo_end = param->pad_w_out + param->W;
   const float nhw = (float)(nImg * ifh * ifw);
   const float recp_nhw = 1.0f/nhw;
 
   int img, fm, hi, wi, ho, wo;
 
-  LIBXSMM_VLA_DECL(4, const float,         input,      input_ptr,      nFm, ifh, ifw);
-  LIBXSMM_VLA_DECL(4,       float,         dinput,     dinput_ptr,     nFm, ifh, ifw);
-  LIBXSMM_VLA_DECL(4,       float,         dinput_add, dinput_add_ptr, nFm, ifh, ifw);
-  LIBXSMM_VLA_DECL(4, const float,         output,     output_ptr,     nFm, ofh, ofw);
-  LIBXSMM_VLA_DECL(4,       float,         doutput,    doutput_ptr,    nFm, ofh, ofw);
+  LIBXSMM_VLA_DECL(4, const float,         input,      input_ptr,      nFm, ifhp, ifwp);
+  LIBXSMM_VLA_DECL(4,       float,         dinput,     dinput_ptr,     nFm, ifhp, ifwp);
+  LIBXSMM_VLA_DECL(4,       float,         dinput_add, dinput_add_ptr, nFm, ifhp, ifwp);
+  LIBXSMM_VLA_DECL(4, const float,         output,     output_ptr,     nFm, ofhp, ofwp);
+  LIBXSMM_VLA_DECL(4,       float,         doutput,    doutput_ptr,    nFm, ofhp, ofwp);
   LIBXSMM_UNUSED(beta_ptr);
 
   if ( param->norm_type == 0 ) {
@@ -2888,12 +2958,40 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
       del_beta_ptr[fm] = 0.0f;
 
       for ( img = 0; img < nImg; img++ ) {
-        for ( hi = 0, ho = 0; hi < ifh; hi += sh, ho++ ) {
-          for ( wi = 0, wo = 0; wi < ifw; wi += sw, wo++ ) {
-                  float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifh, ifw);
-            const float  output_val        =  LIBXSMM_VLA_ACCESS(4,     output, img, fm, ho, wo, fm, ofh, ofw);
-            const float  input_val         =  LIBXSMM_VLA_ACCESS(4,      input, img, fm, hi, wi, fm, ifh, ifw);
-                  float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofh, ofw);
+
+        /* Handling the padding at the start */
+        for (ho = 0; ho < ho_start; ho++) {
+          for (wo = 0; wo < ofwp; wo++) {
+            float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
+            *del_output_ptr = 0;
+          }
+        }
+        for (wo = 0; wo < wo_start; wo++) {
+          for (ho = 0; ho < ofhp; ho++) {
+            float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
+            *del_output_ptr = 0;
+          }
+        }
+        for (hi = 0; hi < hi_start; hi++) {
+          for (wi = 0; wi < ifwp; wi++) {
+            float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifhp, ifwp);
+            *del_input_add_ptr = 0;
+          }
+        }
+        for (wi = 0; wi < wi_start; wi++) {
+          for (hi = 0; hi < ifhp; hi++) {
+            float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifhp, ifwp);
+            *del_input_add_ptr = 0;
+          }
+        }
+
+        /* main (middle ~ internal) part */
+        for ( hi = hi_start, ho = ho_start; hi < hi_end; hi += sh, ho++ ) {
+          for ( wi = wi_start, wo = wo_start; wi < wi_end; wi += sw, wo++ ) {
+                  float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifhp, ifwp);
+            const float  output_val        =  LIBXSMM_VLA_ACCESS(4,     output, img, fm, ho, wo, fm, ofhp, ofwp);
+            const float  input_val         =  LIBXSMM_VLA_ACCESS(4,      input, img, fm, hi, wi, fm, ifhp, ifwp);
+                  float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
 
             /* (inv) ReLU/mask */
             if ( (param->fuse_type == 1) || (param->fuse_type == 3) || (param->fuse_type == 4) || (param->fuse_type == 5) ) {
@@ -2908,6 +3006,32 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
             del_beta_ptr[fm]  += *del_output_ptr;
           }
         }
+
+        /* Handling the padding at the end */
+        for (ho = ho_end; ho < ofhp; ho++) {
+          for (wo = 0; wo < ofwp; wo++) {
+            float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
+            *del_output_ptr = 0;
+          }
+        }
+        for (ho = ho_end; ho < ofhp; ho++) {
+          for (wo = 0; wo < ofwp; wo++) {
+            float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
+            *del_output_ptr = 0;
+          }
+        }
+        for (hi = hi_end; hi < ifhp; hi++) {
+          for (wi = 0; wi < ifwp; wi++) {
+            float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifhp, ifwp);
+            *del_input_add_ptr = 0;
+          }
+        }
+        for (hi = hi_end; hi < ifhp; hi++) {
+          for (wi = 0; wi < ifwp; wi++) {
+            float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifhp, ifwp);
+            *del_input_add_ptr = 0;
+          }
+        }
       }
     }
   }
@@ -2917,16 +3041,46 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
 #endif
   for ( img = 0; img < nImg; img++ ) {
     for ( fm = 0; fm < nFm; fm++ ) {
-      for ( hi = 0, ho = 0; hi < ifh; hi += sh, ho++ ) {
-        for ( wi = 0, wo = 0; wi < ifw; wi += sw, wo++) {
-                float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifh, ifw);
-          const float  input_val      =  LIBXSMM_VLA_ACCESS(4,      input, img, fm, hi, wi, fm, ifh, ifw);
-          const float  del_output_val =  LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofh, ofw);
+      /* Handling the padding at the start */
+      for (hi = 0; hi < hi_start; hi++) {
+        for (wi = 0; wi < ifwp; wi++) {
+          float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifhp, ifwp);
+          *del_input_ptr = 0;
+        }
+      }
+      for (wi = 0; wi < wi_start; wi++) {
+        for (hi = 0; hi < ifhp; hi++) {
+          float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifhp, ifwp);
+          *del_input_ptr = 0;
+        }
+      }
+
+      /* main (middle ~ internal) part */
+      for ( hi = hi_start, ho = ho_start; hi < hi_end; hi += sh, ho++ ) {
+        for ( wi = wi_start, wo = wo_start; wi < wi_end; wi += sw, wo++) {
+                float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifhp, ifwp);
+          const float  input_val      =  LIBXSMM_VLA_ACCESS(4,      input, img, fm, hi, wi, fm, ifhp, ifwp);
+          const float  del_output_val =  LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
 
           *del_input_ptr = gamma_ptr[fm] * rcpstddev_ptr[fm] * recp_nhw * (nhw * del_output_val -
                     (del_beta_ptr[fm] + (input_val - expectval_ptr[fm]) * del_gamma_ptr[fm] * rcpstddev_ptr[fm]));
         }
       }
+
+      /* Handling the padding at the end */
+      for (hi = hi_end; hi < ifhp; hi++) {
+        for (wi = 0; wi < ifwp; wi++) {
+          float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifhp, ifwp);
+          *del_input_ptr = 0;
+        }
+      }
+      for (hi = hi_end; hi < ifhp; hi++) {
+        for (wi = 0; wi < ifwp; wi++) {
+          float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifhp, ifwp);
+          *del_input_ptr = 0;
+        }
+      }
+
     }
   }
 }

--- a/samples/deeplearning/libxsmm_dnn/include/dnn_common.h
+++ b/samples/deeplearning/libxsmm_dnn/include/dnn_common.h
@@ -3010,13 +3010,13 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
         /* Handling the padding at the end */
         for (ho = ho_end; ho < ofhp; ho++) {
           for (wo = 0; wo < ofwp; wo++) {
-            float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
+            float* del_output_ptr = &LIBXSMM_VLA_ACCESS(4, doutput, img, fm, ho, wo, fm, ofhp, ofwp);
             *del_output_ptr = 0;
           }
         }
-        for (ho = ho_end; ho < ofhp; ho++) {
-          for (wo = 0; wo < ofwp; wo++) {
-            float* del_output_ptr    = &LIBXSMM_VLA_ACCESS(4,    doutput, img, fm, ho, wo, fm, ofhp, ofwp);
+        for (wo = wo_end; wo < ofwp; wo++) {
+          for (ho = 0; ho < ofhp; ho++) {
+            float* del_output_ptr = &LIBXSMM_VLA_ACCESS(4, doutput, img, fm, ho, wo, fm, ofhp, ofwp);
             *del_output_ptr = 0;
           }
         }
@@ -3026,8 +3026,8 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
             *del_input_add_ptr = 0;
           }
         }
-        for (hi = hi_end; hi < ifhp; hi++) {
-          for (wi = 0; wi < ifwp; wi++) {
+        for (wi = wi_end; wi < ifwp; wi++) {
+          for (hi = 0; hi < ifhp; hi++) {
             float* del_input_add_ptr = &LIBXSMM_VLA_ACCESS(4, dinput_add, img, fm, hi, wi, fm, ifhp, ifwp);
             *del_input_add_ptr = 0;
           }
@@ -3074,8 +3074,8 @@ LIBXSMM_INLINE void naive_fusedbatchnorm_bp(naive_fusedbatchnorm_t* param, const
           *del_input_ptr = 0;
         }
       }
-      for (hi = hi_end; hi < ifhp; hi++) {
-        for (wi = 0; wi < ifwp; wi++) {
+      for (wi = wi_end; wi < ifwp; wi++) {
+        for (hi = 0; hi < ifhp; hi++) {
           float* del_input_ptr  = &LIBXSMM_VLA_ACCESS(4,     dinput, img, fm, hi, wi, fm, ifhp, ifwp);
           *del_input_ptr = 0;
         }

--- a/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
+++ b/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
@@ -44,6 +44,7 @@ typedef struct libxsmm_dnn_bn_fwd_config {
   libxsmm_blasint  bc;
   libxsmm_blasint  CP;
   libxsmm_blasint  num_HW_blocks;
+  libxsmm_blasint  num_W_blocks;
   libxsmm_blasint  pad_h_in;
   libxsmm_blasint  pad_w_in;
   libxsmm_blasint  pad_h_out;
@@ -59,7 +60,10 @@ typedef struct libxsmm_dnn_bn_fwd_config {
 
   libxsmm_matrix_eqn_function  func10;
   libxsmm_meltwfunction_unary  reduce_HW_kernel;
+  libxsmm_meltwfunction_unary  reduce_W_kernel;
   libxsmm_meltwfunction_unary  all_zero_kernel;
+  libxsmm_meltwfunction_unary  all_zero_hp_kernel;
+  libxsmm_meltwfunction_unary  all_zero_wp_kernel;
   libxsmm_meltwfunction_binary helper_add_kernel;
   libxsmm_dnn_bn_fuse        fuse_type;
 } libxsmm_dnn_bn_fwd_config;

--- a/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
+++ b/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
@@ -49,6 +49,7 @@ typedef struct libxsmm_dnn_bn_fwd_config {
   libxsmm_blasint  pad_w_in;
   libxsmm_blasint  pad_h_out;
   libxsmm_blasint  pad_w_out;
+  libxsmm_blasint  use_hw_blocking;
   libxsmm_blasint  threads;
   size_t           scratch_size;
 
@@ -59,8 +60,7 @@ typedef struct libxsmm_dnn_bn_fwd_config {
   libxsmm_barrier* barrier;
 
   libxsmm_matrix_eqn_function  func10;
-  libxsmm_meltwfunction_unary  reduce_HW_kernel;
-  libxsmm_meltwfunction_unary  reduce_W_kernel;
+  libxsmm_meltwfunction_unary  reduce_kernel;
   libxsmm_meltwfunction_unary  all_zero_kernel;
   libxsmm_meltwfunction_unary  all_zero_hp_kernel;
   libxsmm_meltwfunction_unary  all_zero_wp_kernel;
@@ -81,6 +81,7 @@ typedef struct libxsmm_dnn_bn_bwd_config {
   libxsmm_blasint  pad_w_in;
   libxsmm_blasint  pad_h_out;
   libxsmm_blasint  pad_w_out;
+  libxsmm_blasint  use_hw_blocking;
   libxsmm_blasint  threads;
   size_t           scratch_size;
 

--- a/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
+++ b/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
@@ -94,6 +94,8 @@ typedef struct libxsmm_dnn_bn_bwd_config {
   libxsmm_matrix_eqn_function  dbeta_func;
   libxsmm_matrix_eqn_function  din_func;
   libxsmm_meltwfunction_unary  all_zero_kernel;
+  libxsmm_meltwfunction_unary  all_zero_hp_kernel;
+  libxsmm_meltwfunction_unary  all_zero_wp_kernel;
   libxsmm_meltwfunction_binary helper_add_kernel;
   libxsmm_meltwfunction_unary  helper_copy_kernel;
   libxsmm_meltwfunction_unary  inv_relu_kernel;

--- a/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
+++ b/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
@@ -44,6 +44,10 @@ typedef struct libxsmm_dnn_bn_fwd_config {
   libxsmm_blasint  bc;
   libxsmm_blasint  CP;
   libxsmm_blasint  num_HW_blocks;
+  libxsmm_blasint  pad_h_in;
+  libxsmm_blasint  pad_w_in;
+  libxsmm_blasint  pad_h_out;
+  libxsmm_blasint  pad_w_out;
   libxsmm_blasint  threads;
   size_t           scratch_size;
 
@@ -68,6 +72,10 @@ typedef struct libxsmm_dnn_bn_bwd_config {
   libxsmm_blasint  bc;
   libxsmm_blasint  CP;
   libxsmm_blasint  num_HW_blocks;
+  libxsmm_blasint  pad_h_in;
+  libxsmm_blasint  pad_w_in;
+  libxsmm_blasint  pad_h_out;
+  libxsmm_blasint  pad_w_out;
   libxsmm_blasint  threads;
   size_t           scratch_size;
 
@@ -89,10 +97,12 @@ typedef struct libxsmm_dnn_bn_bwd_config {
 } libxsmm_dnn_bn_bwd_config;
 
 LIBXSMM_API libxsmm_dnn_bn_fwd_config setup_libxsmm_dnn_bn_fwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_blasint H, libxsmm_blasint W, libxsmm_blasint bc,
+                                 libxsmm_blasint pad_h_in, libxsmm_blasint pad_w_in, libxsmm_blasint pad_h_out, libxsmm_blasint pad_w_out,
                                  libxsmm_blasint threads, libxsmm_dnn_bn_fuse fuse_type,
                                  libxsmm_datatype datatype_in, libxsmm_datatype datatype_out, libxsmm_datatype datatype_comp );
 
 LIBXSMM_API libxsmm_dnn_bn_bwd_config setup_libxsmm_dnn_bn_bwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_blasint H, libxsmm_blasint W, libxsmm_blasint bc,
+                                 libxsmm_blasint pad_h_in, libxsmm_blasint pad_w_in, libxsmm_blasint pad_h_out, libxsmm_blasint pad_w_out,
                                  libxsmm_blasint threads, libxsmm_dnn_bn_fuse fuse_type,
                                  libxsmm_datatype datatype_in, libxsmm_datatype datatype_out, libxsmm_datatype datatype_comp );
 

--- a/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
+++ b/samples/deeplearning/libxsmm_dnn/include/libxsmm_dnn_fusedbn.h
@@ -76,6 +76,7 @@ typedef struct libxsmm_dnn_bn_bwd_config {
   libxsmm_blasint  bc;
   libxsmm_blasint  CP;
   libxsmm_blasint  num_HW_blocks;
+  libxsmm_blasint  num_W_blocks;
   libxsmm_blasint  pad_h_in;
   libxsmm_blasint  pad_w_in;
   libxsmm_blasint  pad_h_out;

--- a/samples/deeplearning/libxsmm_dnn/src/libxsmm_dnn_fusedbn.c
+++ b/samples/deeplearning/libxsmm_dnn/src/libxsmm_dnn_fusedbn.c
@@ -193,7 +193,10 @@ LIBXSMM_API libxsmm_dnn_bn_fwd_config setup_libxsmm_dnn_bn_fwd(libxsmm_blasint N
   arg_metadata[0].eqn_idx     = my_eqn10;
   arg_metadata[0].in_arg_pos  = 0;
   arg_shape[0].m    = res.bc;                                      /* x = [HW, bc] */
-  arg_shape[0].n    = res.H*res.W /res.num_HW_blocks;
+  if (res.pad_w_out != 0 || res.pad_h_out != 0)
+    arg_shape[0].n    = res.W /res.num_W_blocks;
+  else
+    arg_shape[0].n    = res.H*res.W /res.num_HW_blocks;
   arg_shape[0].ld   = ld;
   arg_shape[0].type = res.datatype_in;
   libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[0], arg_shape[0], arg_singular_attr);
@@ -218,14 +221,20 @@ LIBXSMM_API libxsmm_dnn_bn_fwd_config setup_libxsmm_dnn_bn_fwd(libxsmm_blasint N
     arg_metadata[5].eqn_idx     = my_eqn10;
     arg_metadata[5].in_arg_pos  = 5;
     arg_shape[5].m    = res.bc;                                      /* inp_add = [HW, bc] */
-    arg_shape[5].n    = res.H*res.W / res.num_HW_blocks;
+    if (res.pad_w_out != 0 || res.pad_h_out != 0)
+      arg_shape[5].n    = res.W /res.num_W_blocks;
+    else
+      arg_shape[5].n    = res.H*res.W / res.num_HW_blocks;
     arg_shape[5].ld   = ld;
     arg_shape[5].type = res.datatype_in;
     libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[5], arg_shape[5], arg_singular_attr);
   }
 
   eqn_out_arg_shape.m    = res.bc;                                 /* y = [HW, bc] */
-  eqn_out_arg_shape.n    = res.H*res.W / res.num_HW_blocks;
+  if (res.pad_w_out != 0 || res.pad_h_out != 0)
+    eqn_out_arg_shape.n    = res.W /res.num_W_blocks;
+  else
+    eqn_out_arg_shape.n    = res.H*res.W / res.num_HW_blocks;
   eqn_out_arg_shape.ld   = ld;
   eqn_out_arg_shape.type = res.datatype_out;
 
@@ -408,7 +417,10 @@ LIBXSMM_API libxsmm_dnn_bn_bwd_config setup_libxsmm_dnn_bn_bwd(libxsmm_blasint N
   arg_metadata[0].eqn_idx     = my_eqn11;
   arg_metadata[0].in_arg_pos  = 0;
   arg_shape[0].m    = res.bc;                                      /* inp [HW, bc] */
-  arg_shape[0].n    = res.H*res.W /res.num_HW_blocks;
+  if (res.pad_w_in != 0 || res.pad_h_in != 0)
+    arg_shape[0].n    = res.W /res.num_W_blocks;
+  else
+    arg_shape[0].n    = res.H*res.W /res.num_HW_blocks;
   arg_shape[0].ld   = ld;
   arg_shape[0].type = res.datatype_in;
   libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[0], arg_shape[0], arg_singular_attr);
@@ -432,7 +444,10 @@ LIBXSMM_API libxsmm_dnn_bn_bwd_config setup_libxsmm_dnn_bn_bwd(libxsmm_blasint N
   arg_metadata[3].eqn_idx     = my_eqn11;
   arg_metadata[3].in_arg_pos  = 3;
   arg_shape[3].m    = res.bc;                                      /* dout [HW, bc] */
-  arg_shape[3].n    = res.H*res.W/res.num_HW_blocks;
+  if (res.pad_w_in != 0 || res.pad_h_in != 0)
+    arg_shape[3].n    = res.W /res.num_W_blocks;
+  else
+    arg_shape[3].n    = res.H*res.W/res.num_HW_blocks;
   arg_shape[3].ld   = ld;
   arg_shape[3].type = res.datatype_out;
   libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[3], arg_shape[3], arg_singular_attr);
@@ -474,7 +489,10 @@ LIBXSMM_API libxsmm_dnn_bn_bwd_config setup_libxsmm_dnn_bn_bwd(libxsmm_blasint N
   arg_metadata[0].eqn_idx     = my_eqn12;
   arg_metadata[0].in_arg_pos  = 3;
   arg_shape[0].m    = res.bc;                                      /* dout [HW, bc] */
-  arg_shape[0].n    = res.H*res.W /res.num_HW_blocks;
+  if (res.pad_w_in != 0 || res.pad_h_in != 0)
+    arg_shape[0].n    = res.W /res.num_W_blocks;
+  else
+    arg_shape[0].n    = res.H*res.W /res.num_HW_blocks;
   arg_shape[0].ld   = ld;
   arg_shape[0].type = res.datatype_out;
   libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[0], arg_shape[0], arg_singular_attr);

--- a/samples/deeplearning/libxsmm_dnn/src/libxsmm_dnn_fusedbn.c
+++ b/samples/deeplearning/libxsmm_dnn/src/libxsmm_dnn_fusedbn.c
@@ -14,6 +14,7 @@
 #define BITS_PER_CHAR (8)
 
 LIBXSMM_API libxsmm_dnn_bn_fwd_config setup_libxsmm_dnn_bn_fwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_blasint H, libxsmm_blasint W, libxsmm_blasint bc,
+                                 libxsmm_blasint pad_h_in, libxsmm_blasint pad_w_in, libxsmm_blasint pad_h_out, libxsmm_blasint pad_w_out,
                                  libxsmm_blasint threads, libxsmm_dnn_bn_fuse fuse_type,
                                  libxsmm_datatype datatype_in, libxsmm_datatype datatype_out, libxsmm_datatype datatype_comp ) {
   libxsmm_dnn_bn_fwd_config res;
@@ -52,6 +53,10 @@ LIBXSMM_API libxsmm_dnn_bn_fwd_config setup_libxsmm_dnn_bn_fwd(libxsmm_blasint N
   res.bc = bc;
   res.CP = res.C / res.bc;
   res.num_HW_blocks = (res.H > res.W ? res.H : res.W );
+  res.pad_h_in      = pad_h_in;
+  res.pad_w_in      = pad_w_in;
+  res.pad_h_out     = pad_h_out;
+  res.pad_w_out     = pad_w_out;
   res.threads       = threads;
   res.fuse_type     = fuse_type;
 
@@ -209,6 +214,7 @@ LIBXSMM_API libxsmm_dnn_bn_fwd_config setup_libxsmm_dnn_bn_fwd(libxsmm_blasint N
 }
 
 LIBXSMM_API libxsmm_dnn_bn_bwd_config setup_libxsmm_dnn_bn_bwd(libxsmm_blasint N, libxsmm_blasint C, libxsmm_blasint H, libxsmm_blasint W, libxsmm_blasint bc,
+                                 libxsmm_blasint pad_h_in, libxsmm_blasint pad_w_in, libxsmm_blasint pad_h_out, libxsmm_blasint pad_w_out,
                                  libxsmm_blasint threads, libxsmm_dnn_bn_fuse fuse_type,
                                  libxsmm_datatype datatype_in, libxsmm_datatype datatype_out, libxsmm_datatype datatype_comp ) {
   libxsmm_dnn_bn_bwd_config res;
@@ -247,6 +253,10 @@ LIBXSMM_API libxsmm_dnn_bn_bwd_config setup_libxsmm_dnn_bn_bwd(libxsmm_blasint N
   res.bc            = bc;
   res.CP            = res.C / res.bc;
   res.num_HW_blocks = (res.H > res.W ? res.H : res.W );
+  res.pad_h_in      = pad_h_in;
+  res.pad_w_in      = pad_w_in;
+  res.pad_h_out     = pad_h_out;
+  res.pad_w_out     = pad_w_out;
   res.threads       = threads;
   res.fuse_type     = fuse_type;
 

--- a/samples/deeplearning/libxsmm_dnn/tests/fusedbn/layer_example.c
+++ b/samples/deeplearning/libxsmm_dnn/tests/fusedbn/layer_example.c
@@ -497,7 +497,6 @@ int main( int argc, char* argv[] ) {
       printf("Check-norm    : %.24f\n\n", norms_fwd_mask.normf_rel);
     }
 
-    exit(0);
   } /* checking correctness for FWD */
 
   for (i = 0; i < 1024 * 1024; i++ ) {

--- a/samples/deeplearning/libxsmm_dnn/tests/fusedbn/layer_example.c
+++ b/samples/deeplearning/libxsmm_dnn/tests/fusedbn/layer_example.c
@@ -42,6 +42,8 @@ int main( int argc, char* argv[] ) {
   float *naive_rcpstdev, *naive_dbeta, *naive_dgamma;
   unsigned char *naive_relumask;
 
+  int ifh, ifw, ofh, ofw, ifhp, ifwp, ofhp, ofwp;
+
   int iters     = 100;
   int N         = 28;
   int C         = 2 * 64;
@@ -128,10 +130,12 @@ int main( int argc, char* argv[] ) {
     W = 1;
   }
 
+  /*
   if (pad_w_in || pad_h_in || pad_w_out || pad_h_out) {
     printf("Padding is not supported (must be all 0)\n");
     return -1;
   }
+  */
 
   if ( stride != 1 ) {
     printf("Non-unit stride is not supported \n");
@@ -160,11 +164,31 @@ int main( int argc, char* argv[] ) {
   stride_w = stride;
   stride_h = stride;
 
+  ifh = H;
+  ifw = W;
+  ofh = H;
+  ofw = W;
+
+  ifhp = ifh + 2 * pad_h_in;
+  ifwp = ifw + 2 * pad_w_in;
+  ofhp = ofh + 2 * pad_h_out;
+  ofwp = ofw + 2 * pad_w_out;
+
   /* set struct for naive batch normalization */
   naive_param.N = N;
   naive_param.C = CP*bc;
   naive_param.H = H;
   naive_param.W = W;
+
+  //naive_param.ifhp = ifhp;
+  //naive_param.ifwp = ifwp;
+  //naive_param.ofhp = ofhp;
+  //naive_param.ofwp = ofwp;
+  naive_param.pad_h_in = pad_h_in;
+  naive_param.pad_w_in = pad_w_in;
+  naive_param.pad_h_out = pad_h_out;
+  naive_param.pad_w_out = pad_w_out;
+
   naive_param.stride_h  = stride_h;
   naive_param.stride_w  = stride_w;
   naive_param.norm_type = norm_type; /* 0: full batchnorm, 1: batch scaling only */
@@ -180,83 +204,129 @@ int main( int argc, char* argv[] ) {
   printf("##########################################\n");
   printf("#          Setting Up (Common)           #\n");
   printf("##########################################\n");
-  printf("PARAMS: N:%d  C:%d  CP:%d bc:%d H:%d W:%d STRIDE:%d (PADDING: must be 0s)\n", N, CP*bc, CP, bc, H, W, stride);
+  //printf("PARAMS: N:%d  C:%d  CP:%d bc:%d H:%d W:%d STRIDE:%d (PADDING: must be 0s)\n", N, CP*bc, CP, bc, H, W, stride);
+  printf("PARAMS: N:%d  C:%d  CP:%d bc:%d H:%d W:%d STRIDE:%d PADDING:%d %d %d %d\n", N, CP*bc, CP, bc, H, W, stride, pad_h_in, pad_w_in, pad_h_out, pad_w_out);
   printf("PARAMS: NORM TYPE:%d\n", norm_type);
   printf("PARAMS: FUSE TYPE:%d\n", fuse_type);
   printf("PARAMS: PREC     :%d\n", prec_bf16);
   printf("PARAMS: ITERS:%d", iters); if (LIBXSMM_FEQ(0, check)) printf("  Threads:%d\n", nThreads); else printf("\n");
-  printf("SIZE Input  (MB): %10.2f MiB\n", (double)(N*CP*HW*bc*sizeof(float))/(1024.0*1024.0) );
-  printf("SIZE Output (MB): %10.2f MiB\n", (double)(N*CP*HW*bc*sizeof(float))/(1024.0*1024.0) );
+  printf("SIZE Input  (MB): %10.2f MiB\n", (double)(N*CP*ifhp*ifwp*bc*sizeof(float))/(1024.0*1024.0) );
+  printf("SIZE Output (MB): %10.2f MiB\n", (double)(N*CP*ofhp*ofwp*bc*sizeof(float))/(1024.0*1024.0) );
 
   /* allocate data */
-  eqn_inp        = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  eqn_inp_add    = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  eqn_dinp       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  eqn_dout       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  eqn_dinp_add   = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  eqn_out        = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
+  eqn_inp        = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_inp_add    = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_dinp       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_dout       = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ofhp*ofwp*bc,   2097152);
+  eqn_dinp_add   = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_out        = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ofhp*ofwp*bc,   2097152);
 
-  eqn_inp_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*HW*bc,   2097152);
-  eqn_inp_add_bf16  = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*HW*bc,   2097152);
-  eqn_dinp_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*HW*bc,   2097152);
-  eqn_dout_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*HW*bc,   2097152);
-  eqn_dinp_add_bf16 = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*HW*bc,   2097152);
-  eqn_out_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*HW*bc,   2097152);
+  eqn_inp_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_inp_add_bf16  = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_dinp_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_dout_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*ofhp*ofwp*bc,   2097152);
+  eqn_dinp_add_bf16 = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*ifhp*ifwp*bc,   2097152);
+  eqn_out_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*CP*ofhp*ofwp*bc,   2097152);
 
-  naive_eqn_dinp     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  naive_eqn_dout     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  naive_eqn_dinp_add = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
-  naive_eqn_out      = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*HW*bc,   2097152);
+  naive_eqn_dinp     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ifhp*ifwp*bc,   2097152);
+  naive_eqn_dout     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ofhp*ofwp*bc,   2097152);
+  naive_eqn_dinp_add = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ifhp*ifwp*bc,   2097152);
+  naive_eqn_out      = (float*) libxsmm_aligned_malloc( sizeof(float)*N*CP*ofhp*ofwp*bc,   2097152);
 
   eqn_dgamma = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   eqn_dbeta  = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
 
   gamma      = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   beta       = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
-  naive_mean       = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
-  naive_var        = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
+  naive_mean = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
+  naive_var  = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   eqn_mean   = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
   eqn_var    = (float*) libxsmm_aligned_malloc( sizeof(float)*CP*bc,   2097152);
 
   cache_fl   = (float*) libxsmm_aligned_malloc( sizeof(float)*1024*1024,   2097152);
 
-  relumask     = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*CP*HW*bc, 2097152);
-  relumask_uncompressed = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*CP*HW*bc, 2097152);
-  eqn_relumask = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*CP*HW*bc, 2097152);
+  relumask     = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*CP*ofhp*ofwp*bc, 2097152);
+  relumask_uncompressed = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*CP*ofhp*ofwp*bc, 2097152);
+  eqn_relumask = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*CP*ofhp*ofwp*bc, 2097152);
 
-  naive_inp      = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*H*W, 2097152);
-  naive_out      = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*H*W, 2097152);
-  naive_inp_add  = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*H*W, 2097152);
-  naive_dinp     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*H*W, 2097152);
-  naive_dout     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*H*W, 2097152);
-  naive_dinp_add = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*H*W, 2097152);
+  naive_inp      = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ifhp*ifwp, 2097152);
+  naive_out      = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ofhp*ofwp, 2097152);
+  naive_inp_add  = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ifhp*ifwp, 2097152);
+  naive_dinp     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ifhp*ifwp, 2097152);
+  naive_dout     = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ofhp*ofwp, 2097152);
+  naive_dinp_add = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ifhp*ifwp, 2097152);
   naive_dgamma   = (float*) libxsmm_aligned_malloc( sizeof(float)*C,       2097152);
   naive_dbeta    = (float*) libxsmm_aligned_malloc( sizeof(float)*C,       2097152);
   naive_rcpstdev = (float*) libxsmm_aligned_malloc( sizeof(float)*C,       2097152);
-  naive_relumask = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*C*H*W, 2097152);
+  naive_relumask = (unsigned char*) libxsmm_aligned_malloc( sizeof(unsigned char)*N*C*ofhp*ofwp, 2097152);
 
   /* Allocate bf16 counterparts */
-  naive_inp_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*H*W, 2097152);
-  naive_out_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*H*W, 2097152);
-  naive_inp_add_bf16  = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*H*W, 2097152);
-  naive_dinp_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*H*W, 2097152);
-  naive_dout_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*H*W, 2097152);
-  naive_dinp_add_bf16 = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*H*W, 2097152);
+  naive_inp_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*ifhp*ifwp, 2097152);
+  naive_out_bf16      = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*ofhp*ofwp, 2097152);
+  naive_inp_add_bf16  = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*ifhp*ifwp, 2097152);
+  naive_dinp_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*ifhp*ifwp, 2097152);
+  naive_dout_bf16     = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*ofhp*ofwp, 2097152);
+  naive_dinp_add_bf16 = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*N*C*ifhp*ifwp, 2097152);
 
   /* initialize data */
-  init_buf(naive_inp,      N*CP*HW*bc, 1, 0);
-  init_buf(naive_inp_add,  N*CP*HW*bc, 1, 0);
-  init_buf(naive_dinp,     N*CP*HW*bc, 1, 0);
-  init_buf(naive_dout,     N*CP*HW*bc, 1, 0);
+  // while debugging
+  if (pad_h_in != 0 || pad_w_in != 0) {
+    int i, j;
+    float * tmp_inp = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ifhp*ifwp, 2097152);
+    init_buf(tmp_inp,      N*CP*ifh*ifw*bc, 1, 0);
+    const int hi_start = pad_h_in;
+    const int wi_start = pad_w_in;
+    const int hi_end = pad_h_in + H;
+    const int wi_end = pad_w_in + W;
+
+    zero_buf(naive_inp, N*CP*ifhp*ifwp*bc);
+    for (i = 0; i < ifh; i++) {
+      for (j = 0; j < ifw; j++) {
+          naive_inp[(i + hi_start) * ifwp + (j + wi_start)] = tmp_inp[i * ifw + j];
+      }
+    }
+
+    libxsmm_free(tmp_inp);
+  } else {
+  init_buf(naive_inp,      N*CP*ifhp*ifwp*bc, 1, 0);
+  }
+  // final should be
+  //init_buf(naive_inp,      N*CP*ifhp*ifwp*bc, 1, 0);
+
+  init_buf(naive_inp_add,  N*CP*ifhp*ifwp*bc, 1, 0);
+  init_buf(naive_dinp,     N*CP*ifhp*ifwp*bc, 1, 0);
+  // while debugging
+  if (pad_h_out != 0 || pad_w_out != 0) {
+    int i, j;
+    float * tmp_dout = (float*) libxsmm_aligned_malloc( sizeof(float)*N*C*ofhp*ofwp, 2097152);
+    init_buf(tmp_dout,      N*CP*ofh*ofw*bc, 1, 0);
+    const int ho_start = pad_h_out;
+    const int wo_start = pad_w_out;
+    const int ho_end = pad_h_out + H;
+    const int wo_end = pad_w_out + W;
+
+    zero_buf(naive_dout, N*CP*ofhp*ofwp*bc);
+    for (i = 0; i < ofh; i++) {
+      for (j = 0; j < ofw; j++) {
+          naive_dout[(i + ho_start) * ofwp + (j + wo_start)] = tmp_dout[i * ofw + j];
+      }
+    }
+
+    libxsmm_free(tmp_dout);
+  } else {
+  init_buf(naive_dout,      N*CP*ofhp*ofwp*bc, 1, 0);
+  }
+  // final should be this
+  //init_buf(naive_dout,     N*CP*ofhp*ofwp*bc, 1, 0);
   init_buf(gamma,          CP*bc,      1, 0);
   init_buf(beta,           CP*bc,      1, 0);
   init_buf(naive_dgamma,   CP*bc,      1, 0);
   init_buf(naive_dbeta,    CP*bc,      1, 0);
 
-  libxsmm_rne_convert_fp32_bf16(naive_inp,     naive_inp_bf16,     N*C*H*W);
-  libxsmm_rne_convert_fp32_bf16(naive_inp_add, naive_inp_add_bf16, N*C*H*W);
-  libxsmm_rne_convert_fp32_bf16(naive_dinp,    naive_dinp_bf16,    N*C*H*W);
-  libxsmm_rne_convert_fp32_bf16(naive_dout,    naive_dout_bf16,    N*C*H*W);
+  libxsmm_rne_convert_fp32_bf16(naive_inp,     naive_inp_bf16,     N*C*ifhp*ifwp);
+  libxsmm_rne_convert_fp32_bf16(naive_inp_add, naive_inp_add_bf16, N*C*ifhp*ifwp);
+  libxsmm_rne_convert_fp32_bf16(naive_dinp,    naive_dinp_bf16,    N*C*ifhp*ifwp);
+  libxsmm_rne_convert_fp32_bf16(naive_dout,    naive_dout_bf16,    N*C*ofhp*ofwp);
 
   if (norm_type == 1) { /* normalize-only batchnorm, hence initializing mean and variance */
     int i;
@@ -274,27 +344,27 @@ int main( int argc, char* argv[] ) {
   copy_buf(naive_dgamma, eqn_dgamma, CP*bc);
   copy_buf(naive_dbeta,  eqn_dbeta,  CP*bc);
 
-  zero_buf_uint8(relumask,              N*CP*HW*bc);
-  zero_buf_uint8(relumask_uncompressed, N*CP*HW*bc);
+  zero_buf_uint8(relumask,              N*CP*ofhp*ofwp*bc);
+  zero_buf_uint8(relumask_uncompressed, N*CP*ofhp*ofwp*bc);
 
   init_buf(cache_fl, 1024*1024, 1, 0);
 
   /* first touch LIBXSMM */
-  zero_buf(eqn_inp,      N*CP*HW*bc);
-  zero_buf(eqn_inp_add,  N*CP*HW*bc);
-  zero_buf(eqn_out,      N*CP*HW*bc);
-  zero_buf(eqn_dinp,     N*CP*HW*bc);
-  zero_buf(eqn_dout,     N*CP*HW*bc);
+  zero_buf(eqn_inp,      N*CP*ifhp*ifwp*bc);
+  zero_buf(eqn_inp_add,  N*CP*ifhp*ifwp*bc);
+  zero_buf(eqn_out,      N*CP*ofhp*ofwp*bc);
+  zero_buf(eqn_dinp,     N*CP*ifhp*ifwp*bc);
+  zero_buf(eqn_dout,     N*CP*ofhp*ofwp*bc);
 
   if (prec_bf16 > 0) {
-    libxsmm_rne_convert_fp32_bf16( naive_inp,          naive_inp_bf16,     N*C*H*W );
-    libxsmm_convert_bf16_f32     ( naive_inp_bf16,     naive_inp,          N*C*H*W );
-    libxsmm_rne_convert_fp32_bf16( naive_inp_add,      naive_inp_add_bf16, N*C*H*W );
-    libxsmm_convert_bf16_f32     ( naive_inp_add_bf16, naive_inp_add,      N*C*H*W );
-    libxsmm_rne_convert_fp32_bf16( naive_dinp,         naive_dinp_bf16,    N*C*H*W );
-    libxsmm_convert_bf16_f32     ( naive_dinp_bf16,    naive_dinp,         N*C*H*W );
-    libxsmm_rne_convert_fp32_bf16( naive_dout,         naive_dout_bf16,    N*C*H*W );
-    libxsmm_convert_bf16_f32     ( naive_dout_bf16,    naive_dout,         N*C*H*W );
+    libxsmm_rne_convert_fp32_bf16( naive_inp,          naive_inp_bf16,     N*C*ifhp*ifwp );
+    libxsmm_convert_bf16_f32     ( naive_inp_bf16,     naive_inp,          N*C*ifhp*ifwp );
+    libxsmm_rne_convert_fp32_bf16( naive_inp_add,      naive_inp_add_bf16, N*C*ifhp*ifwp );
+    libxsmm_convert_bf16_f32     ( naive_inp_add_bf16, naive_inp_add,      N*C*ifhp*ifwp );
+    libxsmm_rne_convert_fp32_bf16( naive_dinp,         naive_dinp_bf16,    N*C*ifhp*ifwp );
+    libxsmm_convert_bf16_f32     ( naive_dinp_bf16,    naive_dinp,         N*C*ifhp*ifwp );
+    libxsmm_rne_convert_fp32_bf16( naive_dout,         naive_dout_bf16,    N*C*ofhp*ofwp );
+    libxsmm_convert_bf16_f32     ( naive_dout_bf16,    naive_dout,         N*C*ofhp*ofwp );
   }
 
   if (LIBXSMM_NEQ(0, check)) {
@@ -308,9 +378,9 @@ int main( int argc, char* argv[] ) {
     naive_fusedbatchnorm_bp(&naive_param, naive_inp, naive_dinp, naive_out, naive_dout, naive_dinp_add,
                                        beta, naive_dbeta, gamma, naive_dgamma, naive_mean, naive_rcpstdev);
 
-    tensor_copy_NCHW_to_NCHWc_uint8 (naive_relumask, relumask_uncompressed, N, C, H, W, bc);
+    tensor_copy_NCHW_to_NCHWc_uint8 (naive_relumask, relumask_uncompressed, N, C, ofhp, ofwp, bc);
     /* since naive implementation returnes the mask with 1 char per entry, after changing layout, a compression into bitmask is needed */
-    mask_compress_uint8 (relumask_uncompressed, relumask, N*CP*H*W*bc);
+    mask_compress_uint8 (relumask_uncompressed, relumask, N*CP*ofhp*ofwp*bc);
 
     printf("##########################################\n");
     printf("#      Computing Reference ... done      #\n");
@@ -322,8 +392,8 @@ int main( int argc, char* argv[] ) {
   printf("##########################################\n");
   /* setup TPPs (standalone or through the configs) */
 
-  libxsmm_dnn_bn_fwd = setup_libxsmm_dnn_bn_fwd(N, C, H, W, bc, nThreads, (libxsmm_dnn_bn_fuse)fuse_type, bn_dtype, bn_dtype, LIBXSMM_DATATYPE_F32);
-  libxsmm_dnn_bn_bwd = setup_libxsmm_dnn_bn_bwd(N, C, H, W, bc, nThreads, (libxsmm_dnn_bn_fuse)fuse_type, bn_dtype, bn_dtype, LIBXSMM_DATATYPE_F32);
+  libxsmm_dnn_bn_fwd = setup_libxsmm_dnn_bn_fwd(N, C, H, W, bc, pad_h_in, pad_w_in, pad_h_out, pad_w_out, nThreads, (libxsmm_dnn_bn_fuse)fuse_type, bn_dtype, bn_dtype, LIBXSMM_DATATYPE_F32);
+  libxsmm_dnn_bn_bwd = setup_libxsmm_dnn_bn_bwd(N, C, H, W, bc, pad_h_in, pad_w_in, pad_h_out, pad_w_out, nThreads, (libxsmm_dnn_bn_fuse)fuse_type, bn_dtype, bn_dtype, LIBXSMM_DATATYPE_F32);
 
   /* allocate and bind scratch */
   if ( libxsmm_dnn_bn_fwd.scratch_size > 0 || libxsmm_dnn_bn_bwd.scratch_size > 0 ) {
@@ -334,11 +404,11 @@ int main( int argc, char* argv[] ) {
 
   /* copy tensors into the right format */
   if (prec_bf16 > 0) {
-    tensor_copy_NCHW_to_NCHWc_bf16( naive_inp_bf16,     eqn_inp_bf16,     N, C, H, W, bc );
-    tensor_copy_NCHW_to_NCHWc_bf16( naive_inp_add_bf16, eqn_inp_add_bf16, N, C, H, W, bc );
+    tensor_copy_NCHW_to_NCHWc_bf16( naive_inp_bf16,     eqn_inp_bf16,     N, C, ifhp, ifwp, bc );
+    tensor_copy_NCHW_to_NCHWc_bf16( naive_inp_add_bf16, eqn_inp_add_bf16, N, C, ifhp, ifwp, bc );
   } else {
-    tensor_copy_NCHW_to_NCHWc( naive_inp,     eqn_inp,     N, C, H, W, bc );
-    tensor_copy_NCHW_to_NCHWc( naive_inp_add, eqn_inp_add, N, C, H, W, bc );
+    tensor_copy_NCHW_to_NCHWc( naive_inp,     eqn_inp,     N, C, ifhp, ifwp, bc );
+    tensor_copy_NCHW_to_NCHWc( naive_inp_add, eqn_inp_add, N, C, ifhp, ifwp, bc );
   }
 
   /* Check correctness */
@@ -360,15 +430,15 @@ int main( int argc, char* argv[] ) {
 
     /* copy out data */
     if (prec_bf16 > 0)
-      libxsmm_convert_bf16_f32( eqn_out_bf16, eqn_out, N*C*H*W );
+      libxsmm_convert_bf16_f32( eqn_out_bf16, eqn_out, N*C*ofhp*ofwp );
 
-    tensor_copy_NCHWc_to_NCHW( eqn_out, naive_eqn_out, N, C, H, W, bc );
+    tensor_copy_NCHWc_to_NCHW( eqn_out, naive_eqn_out, N, C, ofhp, ofwp, bc );
 
     /* compare */
     printf("############################################\n");
     printf("# Correctness FWD Batchnorm - Output       #\n");
     printf("############################################\n");
-    libxsmm_matdiff(&norms_fwd_out, LIBXSMM_DATATYPE_F32, N*CP*HW*bc, 1, naive_out, naive_eqn_out, 0, 0);
+    libxsmm_matdiff(&norms_fwd_out, LIBXSMM_DATATYPE_F32, N*CP*ofhp*ofwp*bc, 1, naive_out, naive_eqn_out, 0, 0);
     printf("L1 reference  : %.25g\n", norms_fwd_out.l1_ref);
     printf("L1 test       : %.25g\n", norms_fwd_out.l1_tst);
     printf("L2 abs.error  : %.24f\n", norms_fwd_out.l2_abs);
@@ -405,7 +475,7 @@ int main( int argc, char* argv[] ) {
       printf("############################################\n");
       printf("# Correctness FWD Batchnorm - Relumask     #\n");
       printf("############################################\n");
-      libxsmm_matdiff(&norms_fwd_mask, LIBXSMM_DATATYPE_I8, N*CP*HW*bc, 1, relumask, eqn_relumask, 0, 0);
+      libxsmm_matdiff(&norms_fwd_mask, LIBXSMM_DATATYPE_I8, N*CP*ofhp*ofwp*bc, 1, relumask, eqn_relumask, 0, 0);
       printf("L1 reference  : %.25g\n", norms_fwd_mask.l1_ref);
       printf("L1 test       : %.25g\n", norms_fwd_mask.l1_tst);
       printf("L2 abs.error  : %.24f\n", norms_fwd_mask.l2_abs);
@@ -470,11 +540,11 @@ int main( int argc, char* argv[] ) {
 
   /* copy tensors into the right format */
   if (prec_bf16 > 0) {
-    tensor_copy_NCHW_to_NCHWc_bf16( naive_inp_bf16,     eqn_inp_bf16,     N, C, H, W, bc );
-    tensor_copy_NCHW_to_NCHWc_bf16( naive_dout_bf16, eqn_dout_bf16, N, C, H, W, bc );
+    tensor_copy_NCHW_to_NCHWc_bf16( naive_inp_bf16,  eqn_inp_bf16,  N, C, ifhp, ifwp, bc );
+    tensor_copy_NCHW_to_NCHWc_bf16( naive_dout_bf16, eqn_dout_bf16, N, C, ofhp, ofwp, bc );
   } else {
-    tensor_copy_NCHW_to_NCHWc( naive_inp,     eqn_inp,     N, C, H, W, bc );
-    tensor_copy_NCHW_to_NCHWc( naive_dout, eqn_dout, N, C, H, W, bc );
+    tensor_copy_NCHW_to_NCHWc( naive_inp,  eqn_inp,  N, C, ifhp, ifwp, bc );
+    tensor_copy_NCHW_to_NCHWc( naive_dout, eqn_dout, N, C, ofhp, ofwp, bc );
   }
 
   if (LIBXSMM_NEQ(0, check)) {
@@ -495,20 +565,20 @@ int main( int argc, char* argv[] ) {
 
     /* copy out data */
     if (prec_bf16 > 0) {
-      libxsmm_convert_bf16_f32( eqn_dinp_bf16, eqn_dinp, N*C*H*W );
-      libxsmm_convert_bf16_f32( eqn_dinp_add_bf16, eqn_dinp_add, N*C*H*W );
-      libxsmm_convert_bf16_f32( eqn_dout_bf16, eqn_dout, N*C*H*W );
+      libxsmm_convert_bf16_f32( eqn_dinp_bf16, eqn_dinp, N*C*ifhp*ifwp );
+      libxsmm_convert_bf16_f32( eqn_dinp_add_bf16, eqn_dinp_add, N*C*ifhp*ifwp );
+      libxsmm_convert_bf16_f32( eqn_dout_bf16, eqn_dout, N*C*ofhp*ofwp );
     }
 
-    tensor_copy_NCHWc_to_NCHW( eqn_dinp, naive_eqn_dinp, N, C, H, W, bc );
-    tensor_copy_NCHWc_to_NCHW( eqn_dinp_add, naive_eqn_dinp_add, N, C, H, W, bc );
-    tensor_copy_NCHWc_to_NCHW( eqn_dout, naive_eqn_dout, N, C, H, W, bc );
+    tensor_copy_NCHWc_to_NCHW( eqn_dinp,     naive_eqn_dinp,     N, C, ifhp, ifwp, bc );
+    tensor_copy_NCHWc_to_NCHW( eqn_dinp_add, naive_eqn_dinp_add, N, C, ifhp, ifwp, bc );
+    tensor_copy_NCHWc_to_NCHW( eqn_dout,     naive_eqn_dout,     N, C, ofhp, ofwp, bc );
 
     /* compare */
     printf("############################################\n");
     printf("# Correctness BWD Batchnorm - Dinput       #\n");
     printf("############################################\n");
-    libxsmm_matdiff(&norms_bwd_din, LIBXSMM_DATATYPE_F32, N*CP*HW*bc, 1, naive_dinp, naive_eqn_dinp, 0, 0);
+    libxsmm_matdiff(&norms_bwd_din, LIBXSMM_DATATYPE_F32, N*CP*ifhp*ifwp*bc, 1, naive_dinp, naive_eqn_dinp, 0, 0);
     printf("L1 reference  : %.25g\n", norms_bwd_din.l1_ref);
     printf("L1 test       : %.25g\n", norms_bwd_din.l1_tst);
     printf("L2 abs.error  : %.24f\n", norms_bwd_din.l2_abs);
@@ -520,7 +590,7 @@ int main( int argc, char* argv[] ) {
     printf("############################################\n");
     printf("# Correctness BWD Batchnorm - Dout         #\n");
     printf("############################################\n");
-    libxsmm_matdiff(&norms_bwd_dout, LIBXSMM_DATATYPE_F32, N*CP*HW*bc, 1, naive_dout, naive_eqn_dout, 0, 0);
+    libxsmm_matdiff(&norms_bwd_dout, LIBXSMM_DATATYPE_F32, N*CP*ofhp*ofwp*bc, 1, naive_dout, naive_eqn_dout, 0, 0);
     printf("L1 reference  : %.25g\n", norms_bwd_dout.l1_ref);
     printf("L1 test       : %.25g\n", norms_bwd_dout.l1_tst);
     printf("L2 abs.error  : %.24f\n", norms_bwd_dout.l2_abs);
@@ -533,7 +603,7 @@ int main( int argc, char* argv[] ) {
       printf("################################################\n");
       printf("# Correctness BWD Batchnorm - Dinput add       #\n");
       printf("################################################\n");
-      libxsmm_matdiff(&norms_bwd_din, LIBXSMM_DATATYPE_F32, N*CP*HW*bc, 1, naive_dinp_add, naive_eqn_dinp_add, 0, 0);
+      libxsmm_matdiff(&norms_bwd_din, LIBXSMM_DATATYPE_F32, N*CP*ifhp*ifwp*bc, 1, naive_dinp_add, naive_eqn_dinp_add, 0, 0);
       printf("L1 reference  : %.25g\n", norms_bwd_din.l1_ref);
       printf("L1 test       : %.25g\n", norms_bwd_din.l1_tst);
       printf("L2 abs.error  : %.24f\n", norms_bwd_din.l2_abs);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2301
+dev/kvoronin/batchnorm_padding-1.17-2302

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2300
+dev/kvoronin/batchnorm_padding-1.17-2301

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2307
+dev/kvoronin/batchnorm_padding-1.17-2308

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2303
+dev/kvoronin/batchnorm_padding-1.17-2304

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2304
+dev/kvoronin/batchnorm_padding-1.17-2305

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2302
+dev/kvoronin/batchnorm_padding-1.17-2303

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2305
+dev/kvoronin/batchnorm_padding-1.17-2306

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2306
+dev/kvoronin/batchnorm_padding-1.17-2307

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-master-1.17-2299
+dev/kvoronin/batchnorm_padding-1.17-2300

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/batchnorm_padding-1.17-2308
+dev/kvoronin/batchnorm_padding-1.17-2310


### PR DESCRIPTION
Rationale: 

- Adding physical padding as an option so that a 3x3 convolution in Resnet-50 can be used with physically padding (hence it must be supported in the preceding and succeeding batchnorms)
- Extended the naive implementation for batchnorm to support padding (and it now zeroes out all the rims in the output tensors)

Summary:
- Added support for physical padding for input/output of the batchnorm.
- For the fwd: rims are ignored in the `inp`, but set to zero in the `out`
- For the bwd: rims are ignored in `dout` but set to zero for `din_add` and `din`

Tested all four combinations (presence/absence of padding for input/output) locally with relu+mask+eltwise fusion.