### PR TITLE
Fixed missing init of SVE predicate registers when storing TPP register blocks.

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-aarch64_sve_tensormults-1.17-2675
+sve_eltwise_pregisters-1.16.3-2681


### PR DESCRIPTION
Most element-wise kernels have the predicate register still set from the loads when executing the stores.
XOR doesn't load and set them (especially p1); this fixes this with the issue of setting them multiple times (see code comment).