### PR TITLE
Added missing initialization for c3 field of the brgemm descriptor in dispatch_brgemm v2 APIs

### DIFF
--- a/src/libxsmm_main.c
+++ b/src/libxsmm_main.c
@@ -3104,12 +3104,15 @@ LIBXSMM_API libxsmm_gemmfunction libxsmm_dispatch_brgemm_v2( const libxsmm_gemm_
     l_gemm_flags, libxsmm_get_gemm_xprefetch((const int*)&prefetch_flags));
 
   /* add more BRGEMM related fields */
-  if ( (brgemm_config.br_type != LIBXSMM_GEMM_BATCH_REDUCE_NONE) && (brgemm_config.br_unroll_hint != 0) ) {
-    desc->c3 = (unsigned char)(((brgemm_config.br_unroll_hint < 255) && (brgemm_config.br_unroll_hint > 0)) ? brgemm_config.br_unroll_hint : 0);
-  }
-  if ( brgemm_config.br_type == LIBXSMM_GEMM_BATCH_REDUCE_STRIDE ) {
-    desc->c1 = (long long)brgemm_config.br_stride_a_hint;
-    desc->c2 = (long long)brgemm_config.br_stride_b_hint;
+  if ( (brgemm_config.br_type != LIBXSMM_GEMM_BATCH_REDUCE_NONE) ) {
+    if ( brgemm_config.br_type == LIBXSMM_GEMM_BATCH_REDUCE_STRIDE ) {
+      desc->c1 = (long long)brgemm_config.br_stride_a_hint;
+      desc->c2 = (long long)brgemm_config.br_stride_b_hint;
+    }
+    if (brgemm_config.br_unroll_hint != 0)
+      desc->c3 = (unsigned char)(((brgemm_config.br_unroll_hint < 255) && (brgemm_config.br_unroll_hint > 0)) ? brgemm_config.br_unroll_hint : 0);
+    else
+      desc->c3 = 0;
   }
 
   /* JIT! */
@@ -3154,12 +3157,15 @@ LIBXSMM_API libxsmm_gemmfunction_ext libxsmm_dispatch_brgemm_ext_v2( const libxs
     l_gemm_flags, libxsmm_get_gemm_xprefetch((const int*)&prefetch_flags));
 
   /* add more BRGEMM related fields */
-  if ( (brgemm_config.br_type != LIBXSMM_GEMM_BATCH_REDUCE_NONE) && (brgemm_config.br_unroll_hint != 0) ) {
-    desc->c3 = (unsigned char)(((brgemm_config.br_unroll_hint < 255) && (brgemm_config.br_unroll_hint > 0)) ? brgemm_config.br_unroll_hint : 0);
-  }
-  if ( brgemm_config.br_type == LIBXSMM_GEMM_BATCH_REDUCE_STRIDE ) {
-    desc->c1 = (long long)brgemm_config.br_stride_a_hint;
-    desc->c2 = (long long)brgemm_config.br_stride_b_hint;
+  if ( (brgemm_config.br_type != LIBXSMM_GEMM_BATCH_REDUCE_NONE) ) {
+    if ( brgemm_config.br_type == LIBXSMM_GEMM_BATCH_REDUCE_STRIDE ) {
+      desc->c1 = (long long)brgemm_config.br_stride_a_hint;
+      desc->c2 = (long long)brgemm_config.br_stride_b_hint;
+    }
+    if (brgemm_config.br_unroll_hint != 0)
+      desc->c3 = (unsigned char)(((brgemm_config.br_unroll_hint < 255) && (brgemm_config.br_unroll_hint > 0)) ? brgemm_config.br_unroll_hint : 0);
+    else
+      desc->c3 = 0;
   }
 
   /* setting binary post-op eltwise fields */

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-master-1.17-2681
+dev/kvoronin/brgemm_unroll_hint_init-1.17-2681


### PR DESCRIPTION
Summary:
Added initialization of c3 field in the brgemm descriptor to libxsmm_dispatch_brgemm_v2 and libxsmm_dispatch_brgemm_ext_v2.

Rationale: Using uninitialized c3 can lead to overflowing the code buffer size since c3 is used to unroll the brgemm kernel (encountered with resnet training experiments).

Tested locally on the failing application code.
