### PR TITLE
Generate static flavors of our PkgConf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1650,7 +1650,7 @@ $(OUTDIR)/libxsmm-static.pc: $(OUTDIR)/libxsmm.$(LIBEXT)
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (,$(ALIAS_PRIVLIBS))
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir} -l:libxsmm.$(SLIBEXT) $(ALIAS_PRIVLIBS)" >>$@
+	@echo "Libs: -L\$${libdir}/libxsmm.$(SLIBEXT) $(ALIAS_PRIVLIBS)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmm $(ALIAS_PRIVLIBS)" >>$@
 endif
@@ -1671,7 +1671,7 @@ $(OUTDIR)/libxsmmf-static.pc: $(OUTDIR)/libxsmmf.$(LIBEXT)
 	@echo "Requires: libxsmmext-static" >>$@
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir} -l:libxsmmf.$(SLIBEXT)" >>$@
+	@echo "Libs: \$${libdir}/libxsmmf.$(SLIBEXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmf" >>$@
 endif
@@ -1690,7 +1690,7 @@ $(OUTDIR)/libxsmmext-static.pc: $(OUTDIR)/libxsmmext.$(LIBEXT)
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (,$(ALIAS_PRIVLIBS_EXT))
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir} -l:libxsmmext.$(SLIBEXT) $(ALIAS_PRIVLIBS_EXT)" >>$@
+	@echo "Libs: -L\$${libdir}/libxsmmext.$(SLIBEXT) $(ALIAS_PRIVLIBS_EXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmext $(ALIAS_PRIVLIBS_EXT)" >>$@
 endif
@@ -1711,7 +1711,7 @@ $(OUTDIR)/libxsmmnoblas-static.pc: $(OUTDIR)/libxsmmnoblas.$(LIBEXT)
 	@echo "Requires: libxsmm-static" >>$@
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir} -l:libxsmmnoblas.$(SLIBEXT)" >>$@
+	@echo "Libs: -L\$${libdir}/libxsmmnoblas.$(SLIBEXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmnoblas" >>$@
 endif

--- a/Makefile
+++ b/Makefile
@@ -1650,7 +1650,7 @@ $(OUTDIR)/libxsmm-static.pc: $(OUTDIR)/libxsmm.$(LIBEXT)
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (,$(ALIAS_PRIVLIBS))
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: \$${libdir}/libxsmm.$(SLIBEXT) $(ALIAS_PRIVLIBS)" >>$@
+	@echo "Libs: -L\$${libdir} -l:libxsmm.$(SLIBEXT) $(ALIAS_PRIVLIBS)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmm $(ALIAS_PRIVLIBS)" >>$@
 endif
@@ -1671,7 +1671,7 @@ $(OUTDIR)/libxsmmf-static.pc: $(OUTDIR)/libxsmmf.$(LIBEXT)
 	@echo "Requires: libxsmmext-static" >>$@
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: \$${libdir}/libxsmmf.$(SLIBEXT)" >>$@
+	@echo "Libs: -L\$${libdir} -l:libxsmmf.$(SLIBEXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmf" >>$@
 endif
@@ -1690,7 +1690,7 @@ $(OUTDIR)/libxsmmext-static.pc: $(OUTDIR)/libxsmmext.$(LIBEXT)
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (,$(ALIAS_PRIVLIBS_EXT))
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: \$${libdir}/libxsmmext.$(SLIBEXT) $(ALIAS_PRIVLIBS_EXT)" >>$@
+	@echo "Libs: -L\$${libdir} -l:libxsmmext.$(SLIBEXT) $(ALIAS_PRIVLIBS_EXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmext $(ALIAS_PRIVLIBS_EXT)" >>$@
 endif
@@ -1711,7 +1711,7 @@ $(OUTDIR)/libxsmmnoblas-static.pc: $(OUTDIR)/libxsmmnoblas.$(LIBEXT)
 	@echo "Requires: libxsmm-static" >>$@
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: \$${libdir}/libxsmmnoblas.$(SLIBEXT)" >>$@
+	@echo "Libs: -L\$${libdir} -l:libxsmmnoblas.$(SLIBEXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmnoblas" >>$@
 endif

--- a/Makefile
+++ b/Makefile
@@ -1650,7 +1650,7 @@ $(OUTDIR)/libxsmm-static.pc: $(OUTDIR)/libxsmm.$(LIBEXT)
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (,$(ALIAS_PRIVLIBS))
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir}/libxsmm.$(SLIBEXT) $(ALIAS_PRIVLIBS)" >>$@
+	@echo "Libs: \$${libdir}/libxsmm.$(SLIBEXT) $(ALIAS_PRIVLIBS)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmm $(ALIAS_PRIVLIBS)" >>$@
 endif
@@ -1690,7 +1690,7 @@ $(OUTDIR)/libxsmmext-static.pc: $(OUTDIR)/libxsmmext.$(LIBEXT)
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (,$(ALIAS_PRIVLIBS_EXT))
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir}/libxsmmext.$(SLIBEXT) $(ALIAS_PRIVLIBS_EXT)" >>$@
+	@echo "Libs: \$${libdir}/libxsmmext.$(SLIBEXT) $(ALIAS_PRIVLIBS_EXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmext $(ALIAS_PRIVLIBS_EXT)" >>$@
 endif
@@ -1711,7 +1711,7 @@ $(OUTDIR)/libxsmmnoblas-static.pc: $(OUTDIR)/libxsmmnoblas.$(LIBEXT)
 	@echo "Requires: libxsmm-static" >>$@
 	@echo "Cflags: -I\$${includedir}" >>$@
 ifneq (Windows_NT,$(UNAME))
-	@echo "Libs: -L\$${libdir}/libxsmmnoblas.$(SLIBEXT)" >>$@
+	@echo "Libs: \$${libdir}/libxsmmnoblas.$(SLIBEXT)" >>$@
 else
 	@echo "Libs: -L\$${libdir} -lxsmmnoblas" >>$@
 endif

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1134,9 +1134,7 @@ ifneq (0,$(INTEL))
     ifneq (Darwin,$(UNAME))
       SLDFLAGS += -static-libgcc
     endif
-    DFLAGS += -D__STATIC=1
   else ifneq (0,$(STATIC))
-    DFLAGS += -D__STATIC=$(STATIC)
     SLDFLAGS += -static
   endif
 else
@@ -1150,9 +1148,7 @@ else
         endif
       endif
     endif
-    DFLAGS += -D__STATIC=1
   else ifneq (0,$(STATIC))
-    DFLAGS += -D__STATIC=$(STATIC)
     ifeq (0,$(shell $(LD) -static -ldummydoesnotexist 2>&1 | grep -q "\-ldummydoesnotexist"; echo "$$?"))
       SLDFLAGS += -static
     endif


### PR DESCRIPTION
Generate static flavors of our PkgConf files. This is desired since LIBXSMM's build system now always generates archives as well as shared libraries. Some scientific applications then quietly flipped to link shared libraries, and some build systems such as CMake/PkgConf have a hard time picking the static flavor. This is unwanted in particular if RPATH is missing and an application may fail at runtime due to missing (shared) libraries.


