### PR TITLE
Backported non-breaking fixes and updates from main branch

### DIFF
--- a/.abi.txt
+++ b/.abi.txt
@@ -89,7 +89,6 @@ libxsmm_dmmcall
 libxsmm_dmmcall_abc
 libxsmm_dmmcall_prf
 libxsmm_dmmdispatch
-libxsmm_dmmdispatch_v2
 libxsmm_dsqrt
 libxsmm_dvalue
 libxsmm_finalize
@@ -132,9 +131,8 @@ libxsmm_generator_spgemm_csc_kernel
 libxsmm_generator_spgemm_csr_kernel
 libxsmm_generator_spgemm_csr_reg_kernel
 libxsmm_get_default_allocator
-libxsmm_get_gemm_auto_prefetch
 libxsmm_get_gemm_prefetch
-libxsmm_get_gemm_xprefetch
+libxsmm_get_gemm_typename
 libxsmm_get_kernel_info
 libxsmm_get_malloc
 libxsmm_get_malloc_info
@@ -303,7 +301,6 @@ libxsmm_rng_set_seed
 libxsmm_rng_u32
 libxsmm_scratch_malloc
 libxsmm_set_default_allocator
-libxsmm_set_gemm_auto_prefetch
 libxsmm_set_malloc
 libxsmm_set_scratch_allocator
 libxsmm_set_scratch_limit
@@ -330,7 +327,6 @@ libxsmm_smmcall
 libxsmm_smmcall_abc
 libxsmm_smmcall_prf
 libxsmm_smmdispatch
-libxsmm_smmdispatch_v2
 libxsmm_ssqrt
 libxsmm_stdio_acquire
 libxsmm_stdio_release

--- a/.env/buildkite.env
+++ b/.env/buildkite.env
@@ -77,6 +77,17 @@ if [ ! "${CHECK_USER}" ]; then
   CHECK_USER=buildkite-slurm
 fi
 
+if [ ! "${ARTIFACT_PATH}" ]; then
+  ARTIFACT_ROOT=${ARTIFACT_ROOT:-${BUILDKITE_BUILD_PATH}/../artifacts}
+  if [ -d "${ARTIFACT_ROOT}" ]; then
+    # ARTIFACT_PATH must be evaluated when used: $(eval "${ARTIFACT_PATH}")
+    ARTIFACT_PATH=" \
+      if [ -d \"${ARTIFACT_ROOT}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}\" ]; then \
+        cd \"${ARTIFACT_ROOT}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}\" && pwd; \
+      fi"
+  fi
+fi
+
 if [ ! "${LAUNCH_CMD}" ] && [ "$(command -v srun)" ]; then
   if [ ! "${SRUN}" ]; then
     SRUN=$(command -v srun)
@@ -115,6 +126,21 @@ if [ ! "${EIGEN}" ]; then
 fi
 if [ ! "${COVID}" ]; then
   export COVID=0
+fi
+
+if [ ! "${BUILD_USER}" ]; then
+  BUILD_USER=${BUILDKITE_BUILD_CREATOR}
+fi
+if [ ! "${BUILD_USER}" ]; then
+  BUILD_USER=${BUILDKITE_BUILD_AUTHOR}
+fi
+if [ "${BUILD_USER}" ]; then
+  read -ra BUILD_USER <<<"${BUILD_USER,,}"
+  if [ "1" != "${#BUILD_USER[@]}" ]; then
+    BUILD_USER="${BUILD_USER[0]:0:1}${BUILD_USER[-1]}"
+  else
+    BUILD_USER="${BUILD_USER[0]}"
+  fi
 fi
 
 if [ ! "${COVERITY_SCAN_USER}" ]; then

--- a/.env/pcl-tiergarten/clang-160.env
+++ b/.env/pcl-tiergarten/clang-160.env
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1090,SC1091
 
-source /swtools/clang/16.0.3/vars.sh
+source /swtools/clang/16.0.4/vars.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/base.env"
 export CC=clang CXX=clang++ #FC=flang-new
 

--- a/documentation/libxsmm_be.md
+++ b/documentation/libxsmm_be.md
@@ -40,19 +40,18 @@ The code generator driver program accepts the following arguments:
 12. Alignment override for A (1 auto, 0 unalignment)
 13. Alignment override for C (1 auto, 0 unalignment)
 14. Architecture (noarch, wsm, snb, hsw, knl, knm, skx, clx, cpx)
-15. Prefetch strategy, see below (only nopf or pfsigonly for "sparse*")
+15. Prefetch strategy, see below (only nopf for "sparse*")
 16. SP (single-precision), DP (double-recision), or I16 (only "dense*")
 17. CSC file in Matrix market format (only if 1st arg. is "sparse*").
 
 <a name="prefetch-strategy"></a>The prefetch strategy can be:
 
 1. "nopf": data is not prefetched, just three arguments: A, B, and C
-2. "pfsigonly": no prefetches, kernel signature: A, B, C, A', B', and C'
-3. "BL2viaC": uses accesses to C to prefetch B'
-4. "AL2": uses accesses to A to prefetch A
-5. "curAL2": prefetches current A ahead in the kernel
-6. "AL2_BL2viaC": combines AL2 and BL2viaC
-7. "curAL2_BL2viaC": combines curAL2 and BL2viaC
+2. "BL2viaC": uses accesses to C to prefetch B'
+3. "AL2": uses accesses to A to prefetch A
+4. "curAL2": prefetches current A ahead in the kernel
+5. "AL2_BL2viaC": combines AL2 and BL2viaC
+6. "curAL2_BL2viaC": combines curAL2 and BL2viaC
 
 Here are some examples of invoking the driver program:
 

--- a/include/libxsmm.h
+++ b/include/libxsmm.h
@@ -90,11 +90,6 @@ LIBXSMM_API int libxsmm_get_verbosity(void);
  */
 LIBXSMM_API void libxsmm_set_verbosity(int level);
 
-/** Get the default prefetch strategy. */
-LIBXSMM_API libxsmm_gemm_prefetch_type libxsmm_get_gemm_auto_prefetch(void);
-/** Set the default prefetch strategy. */
-LIBXSMM_API void libxsmm_set_gemm_auto_prefetch(libxsmm_gemm_prefetch_type strategy);
-
 /** Get information about the matrix multiplication kernel. */
 LIBXSMM_API int libxsmm_get_mmkernel_info(libxsmm_xmmfunction kernel, libxsmm_mmkernel_info* info);
 /** Get information about the matrix eltwise kernel. */
@@ -158,28 +153,6 @@ LIBXSMM_API libxsmm_dmmfunction libxsmm_dmmdispatch_v2( const libxsmm_blasint m,
 LIBXSMM_API libxsmm_smmfunction libxsmm_smmdispatch_v2( const libxsmm_blasint m, const libxsmm_blasint n, const libxsmm_blasint k,
                                                      const libxsmm_blasint* lda, const libxsmm_blasint* ldb, const libxsmm_blasint* ldc,
                                                      const int* basicflags );
-
-/** Query or JIT-generate SMM-kernel; returns NULL if it does not exist or if JIT is not supported (double-precision). */
-LIBXSMM_API libxsmm_dmmfunction libxsmm_dmmdispatch(libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
-  const libxsmm_blasint* lda, const libxsmm_blasint* ldb, const libxsmm_blasint* ldc,
-  const double* alpha, const double* beta, const int* flags, const int* prefetch);
-/** Query or JIT-generate SMM-kernel; returns NULL if it does not exist or if JIT is not supported (single-precision). */
-LIBXSMM_API libxsmm_smmfunction libxsmm_smmdispatch(libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
-  const libxsmm_blasint* lda, const libxsmm_blasint* ldb, const libxsmm_blasint* ldc,
-  const float* alpha, const float* beta, const int* flags, const int* prefetch);
-
-/** Helper for tuning the given gemm_flags for batches of SMMs (NTS-hint). */
-LIBXSMM_API libxsmm_bitfield libxsmm_gemm_batch_flags(
-  int gemm_flags, const libxsmm_gemm_shape* gemm_shape, const void* c,
-  /**
-   * If the returned value is larger than zero, the vector-length (in Bytes)
-   * is larger than C's element-width and it can be used to check against a
-   * stride of subsequent C-addresses, i.e., there is sufficient alignment
-   * if 0 == LIBXSMM_MOD2(stride_in_byte, *vlen) and the tuned flag
-   * can be adopted.
-   * The vlen argument can be NULL if no further check is desired.
-   */
-  int* vlen);
 
 /**
  * Process a series of SMMs (batch). See also libxsmm_gemm_batch/omp.

--- a/include/libxsmm_cpuid.h
+++ b/include/libxsmm_cpuid.h
@@ -62,13 +62,8 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_cpuid_info {
 } libxsmm_cpuid_info;
 
 /** Returns the target architecture and instruction set extensions. */
-#if defined(__cplusplus) /* note: stay compatible with TF */
-LIBXSMM_API int libxsmm_cpuid_x86(libxsmm_cpuid_info* info = NULL);
-LIBXSMM_API int libxsmm_cpuid_arm(libxsmm_cpuid_info* info = NULL);
-#else
-LIBXSMM_API int libxsmm_cpuid_x86(libxsmm_cpuid_info* info);
-LIBXSMM_API int libxsmm_cpuid_arm(libxsmm_cpuid_info* info);
-#endif
+LIBXSMM_API int libxsmm_cpuid_x86(libxsmm_cpuid_info* LIBXSMM_ARGDEF(info, NULL));
+LIBXSMM_API int libxsmm_cpuid_arm(libxsmm_cpuid_info* LIBXSMM_ARGDEF(info, NULL));
 
 /**
  * TODO: limited lifetime API until we have a fully-fledged ARM CPU flags test.
@@ -92,11 +87,7 @@ LIBXSMM_API int libxsmm_cpuid_dot_pack_factor(libxsmm_datatype datatype);
  * The actual code path (as used by LIBXSMM) is determined by
  * libxsmm_[get|set]_target_archid/libxsmm_[get|set]_target_arch.
  */
-#if defined(__cplusplus)
-LIBXSMM_API int libxsmm_cpuid(libxsmm_cpuid_info* info = NULL);
-#else
-LIBXSMM_API int libxsmm_cpuid(libxsmm_cpuid_info* info);
-#endif
+LIBXSMM_API int libxsmm_cpuid(libxsmm_cpuid_info* LIBXSMM_ARGDEF(info, NULL));
 
 /**
  * Names the CPU architecture given by CPUID.

--- a/include/libxsmm_frontend.h
+++ b/include/libxsmm_frontend.h
@@ -574,10 +574,6 @@ LIBXSMM_API void libxsmm_sink(const void* arg, ...);
   libxsmm_blas_gemm(LIBXSMM_DATATYPE_F32, LIBXSMM_DATATYPE_F32, \
     TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC)
 
-/** Translates GEMM prefetch request into prefetch-enumeration (incl. FE's auto-prefetch). */
-LIBXSMM_API libxsmm_gemm_prefetch_type libxsmm_get_gemm_xprefetch(const int* prefetch);
-LIBXSMM_API libxsmm_gemm_prefetch_type libxsmm_get_gemm_prefetch(int prefetch);
-
 /** Determines the given value in double-precision (EXIT_SUCCESS if value is NULL). */
 LIBXSMM_API int libxsmm_dvalue(libxsmm_datatype datatype, const void* value, double* dvalue);
 

--- a/include/libxsmm_fsspmdm.h
+++ b/include/libxsmm_fsspmdm.h
@@ -19,15 +19,22 @@
 /** Opaque type for Fixed-size Sparse Matrix x Dense Matrix (FsSpMDM). */
 LIBXSMM_EXTERN_C typedef struct libxsmm_fsspmdm libxsmm_fsspmdm;
 
+/**
+ * Create a handle used for subsequent execution (libxsmm_fsspmdm_execute),
+ * and optionally benchmark alternative kernels (if timer_tick is given).
+ */
 LIBXSMM_API libxsmm_fsspmdm* libxsmm_fsspmdm_create(libxsmm_datatype datatype,
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
-  const void* alpha, const void* beta, libxsmm_blasint c_is_nt, const void* a_dense);
+  const void* alpha, const void* beta, const void* a_dense, int LIBXSMM_ARGDEF(c_is_nt, 0),
+  unsigned long long LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
 LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
-  double alpha, double beta, libxsmm_blasint c_is_nt, const double* a_dense);
+  double alpha, double beta, const double* a_dense, int LIBXSMM_ARGDEF(c_is_nt, 0),
+  unsigned long long LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
 LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
-  float alpha, float beta, libxsmm_blasint c_is_nt, const float* a_dense);
+  float alpha, float beta, const float* a_dense, int LIBXSMM_ARGDEF(c_is_nt, 0),
+  unsigned long long LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
 
 LIBXSMM_API void libxsmm_fsspmdm_execute(const libxsmm_fsspmdm* handle, const void* B, void* C);
 LIBXSMM_API void libxsmm_dfsspmdm_execute(const libxsmm_dfsspmdm* handle, const double* B, double* C);

--- a/include/libxsmm_macros.h
+++ b/include/libxsmm_macros.h
@@ -115,7 +115,7 @@
   (LIBXSMM_VERSION_NUMBER COMP LIBXSMM_VERSION4(MAJOR, MINOR, UPDATE, PATCH))
 
 /**
- * Macro to check minimum version requiremnts in code, for example:
+ * Macro to check minimum version requirements in code, for example:
  * #if LIBXSMM_VERSION_GE(1, 17, 0, 0)
  * // code requiring version 1.17 or later
  * #else
@@ -272,6 +272,8 @@
 # else
 #   define LIBXSMM_CALLER __FUNCNAME__
 # endif
+/** Function argument with default value (C++). */
+# define LIBXSMM_ARGDEF(ARG, DEF) ARG = DEF
 #else /* C */
 # define LIBXSMM_VARIADIC
 # define LIBXSMM_EXTERN extern
@@ -293,6 +295,8 @@
 #   define LIBXSMM_INLINE_KEYWORD
 #   define LIBXSMM_INLINE_FIXUP
 # endif
+/** Function argument with default value (C++). */
+# define LIBXSMM_ARGDEF(ARG, DEF) ARG
 /* LIBXSMM_ATTRIBUTE_USED: increases compile-time of header-only by a large factor */
 # define LIBXSMM_INLINE static LIBXSMM_INLINE_KEYWORD LIBXSMM_ATTRIBUTE_UNUSED
 #endif /*__cplusplus*/
@@ -541,6 +545,8 @@
 #define LIBXSMM_UP(N, MULT) (LIBXSMM_UPDIV(N, MULT) * (MULT))
 #define LIBXSMM_LO2(N, NPOT) ((N) & ~((NPOT) - 1))
 #define LIBXSMM_UP2(N, NPOT) LIBXSMM_LO2((N) + ((NPOT) - 1), NPOT)
+/** Examples: N+10%->UPF(N,1,10), N-10%->UPF(N,-1,10), N*90%->UPF(N,-1,10) */
+#define LIBXSMM_UPF(N, NOM, DEN) (((N) * ((DEN) + (NOM))) / (DEN))
 #define LIBXSMM_ABS(A) (0 <= (A) ? (A) : -(A))
 #define LIBXSMM_MIN(A, B) ((A) < (B) ? (A) : (B))
 #define LIBXSMM_MAX(A, B) ((A) < (B) ? (B) : (A))
@@ -556,7 +562,7 @@
 #define LIBXSMM_ISNAN(A)  LIBXSMM_NEQ(A, A)
 #define LIBXSMM_NOTNAN(A) LIBXSMM_FEQ(A, A)
 #define LIBXSMM_ROUNDX(TYPE, A) ((TYPE)((long long)(0 <= (A) ? ((double)(A) + 0.5) : ((double)(A) - 0.5))))
-#define LIBXSMM_NEARBYINTX(TYPE, A) ((TYPE)((long long)(LIBXSMM_ROUNDX(TYPE,((double)(A)/2.0))*2)))
+#define LIBXSMM_NEARBYINTX(TYPE, A) ((TYPE)((long long)(LIBXSMM_ROUNDX(TYPE, ((double)(A) / 2.0)) * 2)))
 #define LIBXSMM_CONST_VOID_PTR(A) *((const void**)&(A))
 #define LIBXSMM_EOR(ENUM_TYPE, ENUM, FLAG) ((ENUM_TYPE)(((int)(ENUM)) | ((int)(FLAG))))
 

--- a/include/libxsmm_memory.h
+++ b/include/libxsmm_memory.h
@@ -11,7 +11,7 @@
 #ifndef LIBXSMM_MEMORY_H
 #define LIBXSMM_MEMORY_H
 
-#include <libxsmm_typedefs.h>
+#include "libxsmm_typedefs.h"
 
 #define LIBXSMM_MEMORY127_LOOP(DST, SRC, SIZE, RHS, NTS) do { \
   const signed char libxsmm_memory127_loop_size_ = LIBXSMM_CAST_ICHAR(SIZE); \

--- a/include/libxsmm_typedefs.h
+++ b/include/libxsmm_typedefs.h
@@ -27,7 +27,7 @@
 # define LIBXSMM_BLASINT int
 #endif
 
-/** Generic prefetches; similar to LIBXSMM_PREFETCH_AUTO */
+/** Generic prefetch applicable for all domains. */
 #define LIBXSMM_PREFETCH_SIGONLY 1
 #define LIBXSMM_PREFETCH_NONE 0
 /** Attempt to automatically select a strategy. */
@@ -524,7 +524,7 @@ typedef enum libxsmm_gemm_flags {
 
 /** Enumeration of the available prefetch strategies. */
 typedef enum libxsmm_gemm_prefetch_type {
-  /** No prefetching and no prefetch fn. signature. */
+  /** No data-prefetch. */
   LIBXSMM_GEMM_PREFETCH_NONE               = LIBXSMM_PREFETCH_NONE,
   /** Only function prefetch signature. */
   LIBXSMM_GEMM_PREFETCH_SIGONLY            = LIBXSMM_PREFETCH_SIGONLY,
@@ -683,7 +683,7 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_meltw_unary_param {
 
 /** argument struct for matrix-eltwise: binary */
 LIBXSMM_EXTERN_C typedef struct libxsmm_meltw_binary_param {
-  libxsmm_matrix_op_arg op;   /* op state & paramters */
+  libxsmm_matrix_op_arg op;   /* op state & parameters */
   libxsmm_matrix_arg in0;     /* 1st input  */
   libxsmm_matrix_arg in1;     /* 2nd input  */
   libxsmm_matrix_arg out;     /* output     */

--- a/samples/cp2k/cp2k-dbcsr.cpp
+++ b/samples/cp2k/cp2k-dbcsr.cpp
@@ -156,9 +156,6 @@ int main(int argc, char* argv[])
 
     // initialize LIBXSMM
     libxsmm_init();
-    // some more setup similar to CP2K/intel branch
-    libxsmm_set_gemm_auto_prefetch(LIBXSMM_X86_AVX512_MIC != libxsmm_get_target_archid() ? LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C : LIBXSMM_GEMM_PREFETCH_BL2_VIA_C);
-    //libxsmm_set_dispatch_trylock(1);
 
     fprintf(stdout, "m=%lli n=%lli k=%lli size=%lli memory=%.1f MB (%s)\n\n",
       static_cast<long long>(m), static_cast<long long>(n), static_cast<long long>(k), static_cast<long long>(s),

--- a/samples/utilities/wrap/dgemm.c
+++ b/samples/utilities/wrap/dgemm.c
@@ -58,7 +58,8 @@ void init(int seed, double* dst, BLASINT_TYPE nrows, BLASINT_TYPE ncols, BLASINT
 
 int main(int argc, char* argv[])
 {
-  int nrepeat = (2 == argc ? atoi(argv[1]) : 500);
+  const int arg1 = (2 == argc ? atoi(argv[1]) : 0);
+  int nrepeat = (0 < arg1 ? arg1 : 500);
   const BLASINT_TYPE m = (2 < argc ? atoi(argv[1]) : 23);
   const BLASINT_TYPE k = (3 < argc ? atoi(argv[3]) : m);
   const BLASINT_TYPE n = (2 < argc ? atoi(argv[2]) : k);
@@ -92,17 +93,18 @@ int main(int argc, char* argv[])
   init( 0, c, m, n, ldc, scale);
 
   { /* Call DGEMM */
-# if defined(_OPENMP)
+#if defined(_OPENMP)
     const double start = omp_get_wtime();
-# endif
+#endif
     for (i = 0; i < nrepeat; ++i) {
       GEMM(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc);
     }
-# if defined(_OPENMP)
-    printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
-# else
-    printf("Called %i times.\n", nrepeat);
-# endif
+#if defined(_OPENMP)
+    if (0 < nrepeat) printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
+#else
+    if (0 < nrepeat) printf("Called %i times.\n", nrepeat);
+#endif
+    else fprintf(stderr, "Not executed!\n");
   }
 
   free(a);

--- a/samples/utilities/wrap/dgemm_batch.c
+++ b/samples/utilities/wrap/dgemm_batch.c
@@ -67,7 +67,8 @@ void init(int seed, double* dst, BLASINT_TYPE nrows, BLASINT_TYPE ncols, BLASINT
 
 int main(int argc, char* argv[])
 {
-  int nrepeat = (2 == argc ? atoi(argv[1]) : 500);
+  const int arg1 = (2 == argc ? atoi(argv[1]) : 0);
+  int nrepeat = (0 < arg1 ? arg1 : 500);
   const BLASINT_TYPE m = (2 < argc ? atoi(argv[1]) : 23);
   const BLASINT_TYPE k = (3 < argc ? atoi(argv[3]) : m);
   const BLASINT_TYPE n = (2 < argc ? atoi(argv[2]) : k);
@@ -132,10 +133,11 @@ int main(int argc, char* argv[])
     }
 #endif
 #if defined(GEMM_BATCH) && defined(_OPENMP)
-    printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
+    if (0 < nrepeat) printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
 #else
-    printf("Called %i times.\n", nrepeat);
+    if (0 < nrepeat) printf("Called %i times.\n", nrepeat);
 #endif
+    else fprintf(stderr, "Not executed!\n");
   }
 
   free(pa);

--- a/samples/utilities/wrap/dgemm_batch_strided.c
+++ b/samples/utilities/wrap/dgemm_batch_strided.c
@@ -67,7 +67,8 @@ void init(int seed, double* dst, BLASINT_TYPE nrows, BLASINT_TYPE ncols, BLASINT
 
 int main(int argc, char* argv[])
 {
-  int nrepeat = (2 == argc ? atoi(argv[1]) : 500);
+  const int arg1 = (2 == argc ? atoi(argv[1]) : 0);
+  int nrepeat = (0 < arg1 ? arg1 : 500);
   const BLASINT_TYPE m = (2 < argc ? atoi(argv[1]) : 23);
   const BLASINT_TYPE k = (3 < argc ? atoi(argv[3]) : m);
   const BLASINT_TYPE n = (2 < argc ? atoi(argv[2]) : k);
@@ -131,10 +132,11 @@ int main(int argc, char* argv[])
     }
 #endif
 #if defined(GEMM_BATCH_STRIDED) && defined(_OPENMP)
-    printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
+    if (0 < nrepeat) printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
 #else
-    printf("Called %i times.\n", nrepeat);
+    if (0 < nrepeat) printf("Called %i times.\n", nrepeat);
 #endif
+    else fprintf(stderr, "Not executed!\n");
   }
 
   free(a);

--- a/samples/utilities/wrap/dgemv.c
+++ b/samples/utilities/wrap/dgemv.c
@@ -58,7 +58,8 @@ void init(int seed, double* dst, BLASINT_TYPE nrows, BLASINT_TYPE ncols, BLASINT
 
 int main(int argc, char* argv[])
 {
-  int nrepeat = (2 == argc ? atoi(argv[1]) : 500);
+  const int arg1 = (2 == argc ? atoi(argv[1]) : 0);
+  int nrepeat = (0 < arg1 ? arg1 : 500);
   const BLASINT_TYPE m = (2 < argc ? atoi(argv[1]) : 23);
   const BLASINT_TYPE n = (2 < argc ? atoi(argv[2]) : m);
   const BLASINT_TYPE lda = (3 < argc ? atoi(argv[3]) : m);
@@ -91,17 +92,18 @@ int main(int argc, char* argv[])
   init( 0, y, m, 1, incy, scale);
 
   { /* Call DGEMM */
-# if defined(_OPENMP)
+#if defined(_OPENMP)
     const double start = omp_get_wtime();
-# endif
+#endif
     for (i = 0; i < nrepeat; ++i) {
       GEMV(&trans, &m, &n, &alpha, a, &lda, x, &incx, &beta, y, &incy);
     }
-# if defined(_OPENMP)
-    printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
-# else
-    printf("Called %i times.\n", nrepeat);
-# endif
+#if defined(_OPENMP)
+    if (0 < nrepeat) printf("Called %i times (%f s).\n", nrepeat, omp_get_wtime() - start);
+#else
+    if (0 < nrepeat) printf("Called %i times.\n", nrepeat);
+#endif
+    else fprintf(stderr, "Not executed!\n");
   }
 
   free(a);

--- a/samples/utilities/wrap/wrap-test.sh
+++ b/samples/utilities/wrap/wrap-test.sh
@@ -9,16 +9,15 @@
 ###############################################################################
 # Hans Pabst (Intel Corp.)
 ###############################################################################
+# shellcheck disable=SC2011
 set -eo pipefail
 
 HERE=$(cd "$(dirname "$0")" && pwd -P)
 DEPDIR=${HERE}/../../..
 
-TMPF=$("${DEPDIR}/.mktmp.sh" /tmp/.libxsmm_XXXXXX.out)
 UNAME=$(command -v uname)
 GREP=$(command -v grep)
-SORT=$(command -v sort)
-RM=$(command -v rm)
+CUT=$(command -v cut)
 TR=$(command -v tr)
 
 if [ "Darwin" != "$(${UNAME})" ]; then
@@ -27,64 +26,88 @@ else
   LIBEXT=dylib
 fi
 if [ "$1" ]; then
-  TEST=$1
+  TESTS=$1
   shift
 else
-  TEST=dgemm
+  TESTS="$(ls -1 "${HERE}"/*.c | xargs -I{} basename {} .c)"
 fi
 
-if [ -e "${HERE}/${TEST}-blas" ]; then
-  NAME=$(echo ${TEST} | ${TR} [[:lower:]] [[:upper:]])
-  echo "-----------------------------------"
-  echo "${NAME} (ORIGINAL BLAS)"
-  echo "args    $@"
-  { time "${HERE}/${TEST}-blas" "$@" 2>"${TMPF}"; } 2>&1 | ${GREP} real
-  RESULT=$?
-  if [ 0 != ${RESULT} ]; then
-    echo -n "FAILED(${RESULT}) "; ${SORT} -u "${TMPF}"
-    ${RM} -f "${TMPF}"
-    exit ${RESULT}
-  else
-    echo -n "OK "; ${SORT} -u "${TMPF}"
-  fi
-  echo
+TMPF=$(mktemp)
+trap 'rm ${TMPF}' EXIT
 
-  if [ -e "${DEPDIR}/lib/libxsmmext.${LIBEXT}" ]; then
+# enable interceptor for all cases (for the sake of testing)
+export LIBXSMM_GEMM_WRAP=${LIBXSMM_GEMM_WRAP:-5}
+# set verbosity to check for generated kernels
+export LIBXSMM_VERBOSE=${LIBXSMM_VERBOSE:-3}
+
+for TEST in ${TESTS}; do
+  NAME=$(echo "${TEST}" | ${TR} [[:lower:]] [[:upper:]])
+  KERN=$(echo "${TEST:1}" | ${CUT} -d_ -f1)
+
+  if [ -e "${HERE}/${TEST}-blas" ]; then
     echo "-----------------------------------"
-    echo "${NAME} (LD_PRELOAD)"
-    echo "args    $@"
-    { time \
-      LD_LIBRARY_PATH=${DEPDIR}/lib:${LD_LIBRARY_PATH} LD_PRELOAD=${DEPDIR}/lib/libxsmmext.${LIBEXT} \
-      DYLD_LIBRARY_PATH=${DEPDIR}/lib:${DYLD_LIBRARY_PATH} DYLD_INSERT_LIBRARIES=${DEPDIR}/lib/libxsmmext.${LIBEXT} \
-      "${HERE}/${TEST}-blas" "$@" 2>"${TMPF}"; } 2>&1 | ${GREP} real
+    echo "${NAME} (ORIGINAL BLAS)"
+    if [ "$*" ]; then echo "args    $*"; fi
+    { time "${HERE}/${TEST}-blas" "$*" 2>"${TMPF}"; } 2>&1 | ${GREP} real
     RESULT=$?
-    if [ 0 != ${RESULT} ]; then
-      echo -n "FAILED(${RESULT}) "; ${SORT} -u "${TMPF}"
-      ${RM} -f "${TMPF}"
+    if [ "0" != "${RESULT}" ]; then
+      echo "FAILED(${RESULT})"
       exit ${RESULT}
+    elif ! ${GREP} -q "Registry and code: .\+${KERN}=[[:digit:]]\+" "${TMPF}"; then
+      echo "OK"
+    elif ${GREP} -q "Not executed!" "${TMPF}"; then
+      echo "OK: not executed"
     else
-      echo -n "OK "; ${SORT} -u "${TMPF}"
+      echo "FAILED"
+      exit 1
     fi
     echo
   fi
-fi
 
-if [ -e "${HERE}/${TEST}-wrap" ] && [ -e .state ] && \
-   [ ! "$(${GREP} 'BLAS=0' .state)" ];
-then
-  echo "-----------------------------------"
-  echo "${NAME} (STATIC WRAP)"
-  echo "args    $@"
-  { time "${HERE}/${TEST}-wrap" "$@" 2>"${TMPF}"; } 2>&1 | ${GREP} real
-  RESULT=$?
-  if [ 0 != ${RESULT} ]; then
-    echo -n "FAILED(${RESULT}) "; ${SORT} -u "${TMPF}"
-    ${RM} -f "${TMPF}"
-    exit ${RESULT}
-  else
-    echo -n "OK "; ${SORT} -u "${TMPF}"
+  if [ -e "${HERE}/${TEST}-wrap" ] && [ -e .state ] && \
+     [ ! "$(${GREP} 'BLAS=0' .state)" ];
+  then
+    echo "-----------------------------------"
+    echo "${NAME} (STATIC WRAP)"
+    if [ "$*" ]; then echo "args    $*"; fi
+    { time "${HERE}/${TEST}-wrap" "$*" 2>"${TMPF}"; } 2>&1 | ${GREP} real
+    RESULT=$?
+    if [ "0" != "${RESULT}" ]; then
+      echo "FAILED(${RESULT})"
+      exit ${RESULT}
+    elif ${GREP} -q "Registry and code: .\+${KERN}=[[:digit:]]\+" "${TMPF}"; then
+      echo "OK"
+    elif ${GREP} -q "Not executed!" "${TMPF}"; then
+      echo "OK: not executed"
+    else
+      echo "FAILED"
+      exit 1
+    fi
+    echo
   fi
-  echo
-fi
 
-${RM} -f "${TMPF}"
+  if [ -e "${HERE}/${TEST}-blas" ] && \
+     [ -e "${DEPDIR}/lib/libxsmmext.${LIBEXT}" ];
+  then
+    echo "-----------------------------------"
+    echo "${NAME} (LD_PRELOAD)"
+    if [ "$*" ]; then echo "args    $*"; fi
+    { time \
+      LD_LIBRARY_PATH=${DEPDIR}/lib:${LD_LIBRARY_PATH} LD_PRELOAD=${DEPDIR}/lib/libxsmmext.${LIBEXT} \
+      DYLD_LIBRARY_PATH=${DEPDIR}/lib:${DYLD_LIBRARY_PATH} DYLD_INSERT_LIBRARIES=${DEPDIR}/lib/libxsmm.${LIBEXT} \
+      "${HERE}/${TEST}-blas" "$*" 2>"${TMPF}"; } 2>&1 | ${GREP} real
+    RESULT=$?
+    if [ "0" != "${RESULT}" ]; then
+      echo "FAILED(${RESULT})"
+      exit ${RESULT}
+    elif ${GREP} -q "Registry and code: .\+${KERN}=[[:digit:]]\+" "${TMPF}"; then
+      echo "OK"
+    elif ${GREP} -q "Not executed!" "${TMPF}"; then
+      echo "OK: not executed"
+    else
+      echo "FAILED"
+      exit 1
+    fi
+    echo
+  fi
+done

--- a/scripts/tool_logrept.sh
+++ b/scripts/tool_logrept.sh
@@ -152,7 +152,8 @@ if [ "${LOGDIR}" ]; then
     then FINPUT=""; fi
     SUMMARY=${LOGRPTSUM:-1}
     RESULT="ms"
-  else  # JSON-format
+  fi
+  if [ ! "${FINPUT}" ]; then  # JSON-format
     if ! FINPUT=$("${HERE}/tool_logperf.sh" -j ${LOGFILE});
     then FINPUT=""; fi
     RESULT=${LOGRPTSUM}
@@ -213,9 +214,10 @@ if [ "${LOGDIR}" ]; then
           # normalize path to report file (buildkite-agent)
           REPDIR="$(cd "$(dirname "${REPORT}")" && pwd -P)"
           REPFLE=$(basename "${REPORT}")
-          LABEL=${RPTFMT}
           if [ "$(command -v tr)" ]; then
             LABEL=$(tr "[:lower:]" "[:upper:]" <<<"${RPTFMT}")
+          else
+            LABEL=${RPTFMT^^}
           fi
           if [ -e "${REPDIR}/${REPFLE}" ]; then
             if [ "/" = "${REPDIR:0:1}" ]; then ARTDIR=${REPDIR:1}; else ARTDIR=${REPDIR}; fi

--- a/scripts/tool_pexec.sh
+++ b/scripts/tool_pexec.sh
@@ -219,7 +219,7 @@ if [ "${XARGS}" ] && [ "${FILE}" ] && [ "${SED}" ] && [ "${CAT}" ] && [ "${CUT}"
   done
   PEXEC_SCRARG="\$0"
   if [ "${COUNTER}" != "${TOTAL}" ] || [ "0" = "${PEXEC_IL}" ]; then
-    if [ "0" = "${PEXEC_IL}" ]; then
+    if [ "0" = "${PEXEC_IL}" ] && [ "$(command -v mktemp)" ]; then
       PEXEC_SCRIPT=$(mktemp)
       PEXEC_SCRARG="\$*"
     fi

--- a/scripts/tool_report.py
+++ b/scripts/tool_report.py
@@ -311,32 +311,34 @@ def trend(values):
     """
     Calculate the predicted value (linear trend of history),
     the relative difference of lastest and previous value (rd),
-    the relative difference of lastest and average value (ad),
+    the relative difference of lastest and median value (md),
     the standard deviation (cv), the arithmetic average (avg),
-    and the linear trend (equation).
+    the median value (med), and the linear trend (equation).
     """
-    rd, ad, cv, avg, eqn, size = None, None, None, None, None, len(values)
+    rd, md, cv, avg, med, eqn = None, None, None, None, None, None
+    size = len(values)
     a, b = (values[1] if 1 < size else 0), (values[0] if 0 < size else 0)
     if 1 < size:
         avg = numpy.mean(values[1:])
+        med = numpy.median(values[1:])
     if 0 != a:
         rd = (b - a) / a
-    if 0 != avg:
-        ad = (b - avg) / avg
+    if med:  # not zero/none
+        md = (b - med) / med
     if 2 < size:
         # b: predicted value for x=0 (a * x + b)
         a, b = numpy.polyfit(range(1, size), values[1:], deg=1)
         eqn = numpy.poly1d((a, b))
-        if 0 != avg:
+        if avg:  # not zero/none
             cv = numpy.std(values[1:]) / avg
-    return (b, rd, ad, cv, avg, eqn)
+    return (b, rd, md, cv, avg, med, eqn)
 
 
 def bold(s, cond=True):
     if cond:
         c, t = s.count("$"), s.replace("%", r"\%")
         a = t.replace("$", "") if 0 == (c % 2) else t
-        b = r"$\bf{" + a.replace(" ", "\ ") + "}$"
+        b = r"$\bf{" + a.replace(" ", r"\ ") + "}$"
         return b
     else:
         return s
@@ -344,7 +346,7 @@ def bold(s, cond=True):
 
 def conclude(values, base, unit, accuracy, bounds, lowhigh):
     label, bad = f"{num2fix(values[0], accuracy)} {unit}", False
-    guess, rd, ad, cv, avg, eqn = trend(values)  # unpack
+    guess, rd, md, cv, avg, med, eqn = trend(values)  # unpack
     blist = base.split()
     if 1 < len(blist):  # category and detail
         dlist = blist[1].split("_")
@@ -353,9 +355,9 @@ def conclude(values, base, unit, accuracy, bounds, lowhigh):
                 dlist.remove(c)
         base = f"{blist[0]} {'_'.join(dlist)}"
     # combine relative differences (new value vs last/avg value)
-    xd = max(abs(rd if rd else 0), abs(ad if ad else 0))
+    xd = max(abs(rd if rd else 0), abs(md if md else 0))
     if xd:
-        inum = num2fix(100 * (rd if xd == abs(rd) else ad))
+        inum = num2fix(100 * (rd if xd == abs(rd) else md))
         if cv and bounds and 0 != bounds[0]:
             anum = f"{inum}%" if 0 <= inum else f"|{inum}%|"
             bnum = num2fix(max(100 * cv, 1))
@@ -407,6 +409,9 @@ def create_figure(plots, nplots, resint, untied, addon):
         for data in plots[entry]:
             axes[i].step(data[0], ".:", where="mid", label=data[1])
             axes[i].set_ylabel(f"{entry.upper()} [{data[2]}]")
+            axes[i].tick_params(left=False, labelleft=False, grid_alpha=0.15)
+            axes[i].tick_params(right=True, labelright=True)
+            axes[i].yaxis.grid(True, linestyle="solid")
             axes[i].xaxis.set_ticks(
                 range(len(data[-1])), data[-1], rotation=45
             )
@@ -518,8 +523,8 @@ def main(args, argd, dbfname):
 
     nbuilds, nbuild = 0, int(args.nbuild) if args.nbuild else 0
     if args.infile and (args.infile.is_file() or args.infile.is_fifo()):
-        next = latest + 1
-        nbld = nbuild if 0 < nbuild else next
+        nnew = latest + 1
+        nbld = nbuild if 0 < nbuild else nnew
         name = (
             args.query
             if args.query and (args.query != argd.query or args.query_exact)
@@ -529,7 +534,7 @@ def main(args, argd, dbfname):
             database, str(nbld), name, infokey, info, txt, nentries, nerrors
         )
         if 0 < nentries:
-            latest = next if 0 == nbuild else nbuild
+            latest = nnew if 0 == nbuild else nbuild
     elif args.infile is None and url:  # connect to URL
         try:  # proceeed with cached results in case of an error
             builds = requests.get(url, params=params, headers=auth).json()
@@ -739,7 +744,7 @@ def main(args, argd, dbfname):
             for build in reversed(builds):  # order: latest -> older
                 values, ylabel = database[build][entry][value], None
                 if isinstance(values, dict):  # JSON-format
-                    vals, legd = [], []
+                    vals, legd, detail = [], [], None
                     for key in (k for k in keys if k in values):
                         vscale = 1.0 if 2 > len(qlst) else float(qlst[1])
                         weight = wlist[key] if key in wlist else 1.0
@@ -758,9 +763,19 @@ def main(args, argd, dbfname):
                                 else qlst[2]
                             )
                         lst = key.translate(split).split()
-                        detail = [s for s in lst if s.lower() != qlst[0]]
+                        if lst and all(
+                            lst[0] == s for s in lst if qlst[0] in s.lower()
+                        ):
+                            detail = (
+                                lst[0]
+                                if not detail or detail == lst[0]
+                                else qlst[0]
+                            )
+                        else:
+                            detail = qlst[0]
+                        itm = [s for s in lst if s.lower() != detail]
                         legd.append(
-                            f"{value} {'_'.join(detail)}" if detail else value
+                            f"{value} {'_'.join(itm)}" if itm else value
                         )
                     if vals:
                         if yvalue:
@@ -770,10 +785,10 @@ def main(args, argd, dbfname):
                                 yvalue.append(vals)
                         elif int(build) == latest:
                             yvalue, legend = [vals], legd
-                            if addon == args.branch:
-                                addon = rslt.split(",")[0] + (
-                                    f"@{addon}" if addon else ""
-                                )  # title-addon
+                            if addon == args.branch and detail:
+                                addon = (  # title-addon
+                                    f"{detail}@{addon}" if addon else detail
+                                )
                         xvalue.append(int(build))
                 else:  # telegram format
                     # match --result primarily against "unit"
@@ -881,6 +896,14 @@ def main(args, argd, dbfname):
     nplots = len(plots)
     if 0 < nplots:
         nplots_untied = sum(len(v) for v in plots.values())
+        if 2 > nplots_untied:  # rebuild plots
+            key, val = next(iter(plots.keys())), list(*list(*plots.values()))
+            nplots_untied = len(val)
+            val[0] = list(zip(*val[0]))
+            val[2] = [val[2]] * nplots_untied
+            val[3] = [val[3]] * nplots_untied
+            plots[key] = list(zip(*val))
+
         # auto-adjust y-resolution according to number of plots
         if args.resolution == argd.resolution:  # resolution not user-defined
             resint_untied = copy.deepcopy(resint)

--- a/src/generator_gemm_amx.c
+++ b/src/generator_gemm_amx.c
@@ -1256,7 +1256,7 @@ void libxsmm_generator_gemm_init_micro_kernel_config_tileblocking(libxsmm_gemm_d
   } else if (LIBXSMM_DATATYPE_I8 == LIBXSMM_GEMM_GETENUM_AB_COMMON_PREC( i_xgemm_desc->datatype )) {
     k_blocking = 64;
   } else {
-    /* shouldn't happen */
+    /* should not happen */
     k_blocking = 1; /* surpress div by zero in following while loop */
   }
   while (i_xgemm_desc->k % k_blocking != 0) {
@@ -2018,7 +2018,7 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code*            io_ge
       /* C pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 96, i_gp_reg_mapping->gp_reg_c, 0 );
-      /* batch reduce count & offsett arrays*/
+      /* batch reduce count & offset arrays*/
       if ((l_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (l_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) || (l_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET)) {
         libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                          i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 16, i_gp_reg_mapping->gp_reg_reduce_count, 0 );

--- a/src/generator_matequation_scratch_aarch64.c
+++ b/src/generator_matequation_scratch_aarch64.c
@@ -208,7 +208,7 @@ void libxsmm_generator_matequation_tmp_stack_scratch_aarch64_kernel( libxsmm_gen
       libxsmm_generator_meqn_getval_stack_var( io_generated_code, LIBXSMM_MEQN_STACK_VAR_UNARY_BINARY_PARAM_STRUCT_PTR1, LIBXSMM_X86_GP_REG_RAX);
       libxsmm_generator_meqn_getval_stack_var( io_generated_code, LIBXSMM_MEQN_STACK_VAR_UNARY_BINARY_PARAM_STRUCT_PTR2, LIBXSMM_X86_GP_REG_R9);
 
-      xgemm_desc = (libxsmm_gemm_descriptor*) libxsmm_sgemm_descriptor_init(&blob, m, n, k, lda, ldb, ldc, alpha, beta, gemm_flags, libxsmm_get_gemm_xprefetch(&prefetch));
+      xgemm_desc = (libxsmm_gemm_descriptor*) libxsmm_sgemm_descriptor_init(&blob, m, n, k, lda, ldb, ldc, alpha, beta, gemm_flags, libxsmm_get_gemm_prefetch(prefetch));
 
       libxsmm_generator_gemm_striped_sse_avx_avx2_avx512_kernel( io_generated_code, io_loop_label_tracker, xgemm_desc);
 #endif

--- a/src/libxsmm_ext.c
+++ b/src/libxsmm_ext.c
@@ -16,6 +16,66 @@
 #if defined(LIBXSMM_BUILD_EXT) && !defined(_WIN32)
 
 LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
+void LIBXSMM_FSYMBOL(dgemm_batch_strided)(const char* transa, const char* transb,
+  const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
+  const double* alpha, const double* a, const libxsmm_blasint* lda, const libxsmm_blasint* stride_a,
+  const double* b, const libxsmm_blasint* ldb, const libxsmm_blasint* stride_b,
+  const double* beta, double* c, const libxsmm_blasint* ldc, const libxsmm_blasint* stride_c,
+  const libxsmm_blasint* batchsize) LIBXSMM_BLAS_NOEXCEPT(gemm_batch_strided)
+{
+  LIBXSMM_ASSERT(NULL != transa && NULL != transb && NULL != batchsize);
+  LIBXSMM_ASSERT(NULL != m && NULL != n && NULL != k && NULL != lda && NULL != ldb && NULL != ldc);
+  LIBXSMM_ASSERT(NULL != a && NULL != b && NULL != c && NULL != alpha && NULL != beta);
+  LIBXSMM_ASSERT(NULL != stride_a && NULL != stride_b && NULL != stride_c);
+  if (libxsmm_original_dgemm_batch_strided_function != LIBXSMM_FSYMBOL(__real_dgemm_batch_strided) &&
+      libxsmm_original_dgemm_batch_strided_function != LIBXSMM_FSYMBOL(dgemm_batch_strided))
+  {
+    LIBXSMM_FSYMBOL(__wrap_dgemm_batch_strided)(transa, transb, m, n, k,
+      alpha, a, lda, stride_a, b, ldb, stride_b,
+      beta, c, ldc, stride_c, batchsize);
+  }
+  else {
+    libxsmm_gemm_batch_blas(LIBXSMM_DATATYPE_F64, LIBXSMM_DATATYPE_F64, transa, transb,
+      *m, *n, *k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc, stride_c,
+      -1/*index_stride*/, 0/*index_base*/, *batchsize);
+    libxsmm_blas_error("dgemm_batch_strided")(transa, transb, m, n, k,
+      alpha, a, lda, stride_a, b, ldb, stride_b,
+      beta, c, ldc, stride_c, batchsize);
+  }
+}
+
+
+LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
+void LIBXSMM_FSYMBOL(sgemm_batch_strided)(const char* transa, const char* transb,
+  const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
+  const float* alpha, const float* a, const libxsmm_blasint* lda, const libxsmm_blasint* stride_a,
+  const float* b, const libxsmm_blasint* ldb, const libxsmm_blasint* stride_b,
+  const float* beta, float* c, const libxsmm_blasint* ldc, const libxsmm_blasint* stride_c,
+  const libxsmm_blasint* batchsize) LIBXSMM_BLAS_NOEXCEPT(gemm_batch_strided)
+{
+  LIBXSMM_ASSERT(NULL != transa && NULL != transb && NULL != batchsize);
+  LIBXSMM_ASSERT(NULL != m && NULL != n && NULL != k && NULL != lda && NULL != ldb && NULL != ldc);
+  LIBXSMM_ASSERT(NULL != a && NULL != b && NULL != c && NULL != alpha && NULL != beta);
+  LIBXSMM_ASSERT(NULL != stride_a && NULL != stride_b && NULL != stride_c);
+  if (libxsmm_original_sgemm_batch_strided_function != LIBXSMM_FSYMBOL(__real_sgemm_batch_strided) &&
+      libxsmm_original_sgemm_batch_strided_function != LIBXSMM_FSYMBOL(sgemm_batch_strided))
+  {
+    LIBXSMM_FSYMBOL(__wrap_sgemm_batch_strided)(transa, transb, m, n, k,
+      alpha, a, lda, stride_a, b, ldb, stride_b,
+      beta, c, ldc, stride_c, batchsize);
+  }
+  else {
+    libxsmm_gemm_batch_blas(LIBXSMM_DATATYPE_F32, LIBXSMM_DATATYPE_F32, transa, transb,
+      *m, *n, *k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc, stride_c,
+      -1/*index_stride*/, 0/*index_base*/, *batchsize);
+    libxsmm_blas_error("sgemm_batch_strided")(transa, transb, m, n, k,
+      alpha, a, lda, stride_a, b, ldb, stride_b,
+      beta, c, ldc, stride_c, batchsize);
+  }
+}
+
+
+LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
 void LIBXSMM_FSYMBOL(dgemm_batch)(const char transa_array[], const char transb_array[],
   const libxsmm_blasint m_array[], const libxsmm_blasint n_array[], const libxsmm_blasint k_array[],
   const double alpha_array[], const double* a_array[], const libxsmm_blasint lda_array[],
@@ -152,6 +212,34 @@ void LIBXSMM_FSYMBOL(sgemv)(const char* trans, const libxsmm_blasint* m, const l
   else {
     libxsmm_blas_error("sgemv")(trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
   }
+}
+
+
+LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
+void dgemm_batch_strided(const char* transa, const char* transb,
+  const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
+  const double* alpha, const double* a, const libxsmm_blasint* lda, const libxsmm_blasint* stride_a,
+  const double* b, const libxsmm_blasint* ldb, const libxsmm_blasint* stride_b,
+  const double* beta, double* c, const libxsmm_blasint* ldc, const libxsmm_blasint* stride_c,
+  const libxsmm_blasint* batchsize) LIBXSMM_BLAS_NOEXCEPT(gemm_batch_strided)
+{
+  LIBXSMM_FSYMBOL(dgemm_batch_strided)(transa, transb, m, n, k,
+    alpha, a, lda, stride_a, b, ldb, stride_b,
+    beta, c, ldc, stride_c, batchsize);
+}
+
+
+LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
+void sgemm_batch_strided(const char* transa, const char* transb,
+  const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
+  const float* alpha, const float* a, const libxsmm_blasint* lda, const libxsmm_blasint* stride_a,
+  const float* b, const libxsmm_blasint* ldb, const libxsmm_blasint* stride_b,
+  const float* beta, float* c, const libxsmm_blasint* ldc, const libxsmm_blasint* stride_c,
+  const libxsmm_blasint* batchsize) LIBXSMM_BLAS_NOEXCEPT(gemm_batch_strided)
+{
+  LIBXSMM_FSYMBOL(sgemm_batch_strided)(transa, transb, m, n, k,
+    alpha, a, lda, stride_a, b, ldb, stride_b,
+    beta, c, ldc, stride_c, batchsize);
 }
 
 

--- a/src/libxsmm_gemm.c
+++ b/src/libxsmm_gemm.c
@@ -68,10 +68,6 @@ LIBXSMM_APIVAR_PUBLIC_DEF(unsigned int libxsmm_gemm_taskgrain);
 LIBXSMM_APIVAR_PUBLIC_DEF(int libxsmm_gemm_tasks);
 LIBXSMM_APIVAR_PUBLIC_DEF(int libxsmm_gemm_wrap);
 
-LIBXSMM_APIVAR_PRIVATE_DEF(libxsmm_gemm_prefetch_type libxsmm_gemm_auto_prefetch_default);
-/** Determines the prefetch strategy, which is used in case of LIBXSMM_PREFETCH_AUTO. */
-LIBXSMM_APIVAR_PRIVATE_DEF(libxsmm_gemm_prefetch_type libxsmm_gemm_auto_prefetch);
-
 
 #if defined(LIBXSMM_BUILD)
 LIBXSMM_API LIBXSMM_ATTRIBUTE_WEAK void LIBXSMM_FSYMBOL(__real_dgemm_batch_strided)(
@@ -487,71 +483,19 @@ LIBXSMM_API_INTERN void libxsmm_gemm_finalize(void)
 }
 
 
-LIBXSMM_API libxsmm_gemm_prefetch_type libxsmm_get_gemm_xprefetch(const int* prefetch)
-{
-  LIBXSMM_INIT /* load configuration */
-  return libxsmm_get_gemm_prefetch(NULL == prefetch ? ((int)libxsmm_gemm_auto_prefetch) : *prefetch);
-}
-
-
 LIBXSMM_API libxsmm_gemm_prefetch_type libxsmm_get_gemm_prefetch(int prefetch)
 {
   libxsmm_gemm_prefetch_type result;
-#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
   if (0 > prefetch) {
     LIBXSMM_INIT /* load configuration */
-    result = libxsmm_gemm_auto_prefetch_default;
+    result = ((LIBXSMM_X86_AVX512 >= libxsmm_target_archid || LIBXSMM_X86_AVX512_CORE <= libxsmm_target_archid)
+      ? LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C
+      : LIBXSMM_GEMM_PREFETCH_BL2_VIA_C/*KNx*/);
   }
   else {
     result = (libxsmm_gemm_prefetch_type)prefetch;
   }
-#else /* TODO: full support for Windows calling convention */
-  result = LIBXSMM_GEMM_PREFETCH_NONE;
-  LIBXSMM_UNUSED(prefetch);
-#endif
   return result;
-}
-
-
-LIBXSMM_API_INTERN int libxsmm_gemm_prefetch2uid(libxsmm_gemm_prefetch_type prefetch)
-{
-  switch ((int)prefetch) {
-    case LIBXSMM_GEMM_PREFETCH_SIGONLY:            return 2;
-    case LIBXSMM_GEMM_PREFETCH_BL2_VIA_C:          return 3;
-    case LIBXSMM_GEMM_PREFETCH_AL2_AHEAD:          return 4;
-    case LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD: return 5;
-    case LIBXSMM_GEMM_PREFETCH_AL2:                return 6;
-    case LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C:       return 7;
-    case LIBXSMM_GEMM_PREFETCH_BRGEMM_OOB:         return 8;
-    default: {
-      LIBXSMM_ASSERT(LIBXSMM_GEMM_PREFETCH_NONE == prefetch);
-      return 0;
-    }
-  }
-}
-
-
-LIBXSMM_API_INTERN libxsmm_gemm_prefetch_type libxsmm_gemm_uid2prefetch(int uid)
-{
-  switch (uid) {
-    case 1: return LIBXSMM_GEMM_PREFETCH_NONE;               /* nopf */
-    case 2: return LIBXSMM_GEMM_PREFETCH_SIGONLY;            /* pfsigonly */
-    case 3: return LIBXSMM_GEMM_PREFETCH_BL2_VIA_C;          /* BL2viaC */
-    case 4: return LIBXSMM_GEMM_PREFETCH_AL2_AHEAD;          /* curAL2 */
-    case 5: return LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD; /* curAL2_BL2viaC */
-    case 6: return LIBXSMM_GEMM_PREFETCH_AL2;                /* AL2 */
-    case 7: return LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C;       /* AL2_BL2viaC */
-    case 8: return LIBXSMM_GEMM_PREFETCH_BRGEMM_OOB;
-    default: {
-      if (0 != libxsmm_verbosity) { /* library code is expected to be mute */
-        static int error_once = 0;
-        if (1 == LIBXSMM_ATOMIC_ADD_FETCH(&error_once, 1, LIBXSMM_ATOMIC_RELAXED)) {
-          fprintf(stderr, "LIBXSMM WARNING: invalid prefetch strategy requested!\n");
-        }
-      }
-      return LIBXSMM_GEMM_PREFETCH_NONE;
-    }
-  }
 }
 
 

--- a/src/libxsmm_generator.c
+++ b/src/libxsmm_generator.c
@@ -38,13 +38,13 @@ LIBXSMM_API libxsmm_gemm_descriptor* libxsmm_gemm_descriptor_init(libxsmm_descri
   libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
   libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc, int flags, int prefetch)
 {
+  /*const*/int no_bypass = LIBXSMM_GEMM_NO_BYPASS_DIMS(lda, ldb, ldc) && LIBXSMM_GEMM_NO_BYPASS_DIMS(m, n, k);
   union {
     libxsmm_gemm_descriptor* ptr;
     libxsmm_descriptor_blob* blob;
   } result = { 0 };
-  if ( LIBXSMM_GEMM_NO_BYPASS_DIMS(lda, ldb, ldc)
-    && LIBXSMM_GEMM_NO_BYPASS_DIMS(m, n, k))
-  {
+  LIBXSMM_ASSERT(NULL == result.ptr);
+  if (no_bypass) {
     unsigned char datatype_field[3];
     result.blob = blob;
     LIBXSMM_ASSERT(NULL != result.ptr);
@@ -53,9 +53,6 @@ LIBXSMM_API libxsmm_gemm_descriptor* libxsmm_gemm_descriptor_init(libxsmm_descri
     /* Note: iprec/oprec combination is not checked to omit type-switch (invalid combination may result in BE-error) */
     LIBXSMM_GEMM_DESCRIPTOR(*result.ptr, datatype_field[0], datatype_field[1], datatype_field[2],
                              flags, m, n, k, lda, ldb, ldc, prefetch);
-  }
-  else { /* quiet error (unsupported) */
-    result.ptr = NULL;
   }
   return result.ptr;
 }

--- a/src/libxsmm_malloc.c
+++ b/src/libxsmm_malloc.c
@@ -429,7 +429,8 @@ LIBXSMM_API_INTERN size_t libxsmm_alignment(size_t size, size_t alignment)
 {
   size_t result;
   if ((LIBXSMM_MALLOC_ALIGNFCT * LIBXSMM_MALLOC_ALIGNMAX) <= size) {
-    result = libxsmm_lcm(0 == alignment ? (LIBXSMM_ALIGNMENT) : libxsmm_lcm(alignment, LIBXSMM_ALIGNMENT), LIBXSMM_MALLOC_ALIGNMAX);
+    result = libxsmm_lcm(0 == alignment ? (LIBXSMM_ALIGNMENT)
+      : libxsmm_lcm(alignment, LIBXSMM_ALIGNMENT), LIBXSMM_MALLOC_ALIGNMAX);
   }
   else { /* small-size request */
     if ((LIBXSMM_MALLOC_ALIGNFCT * LIBXSMM_ALIGNMENT) <= size) {
@@ -480,7 +481,8 @@ internal_malloc_info_type* internal_malloc_info(const void* memory, int check)
 #if defined(LIBXSMM_MALLOC_INFO_ALLOCSIZE)
         || (result->size_alloc < result->size)
 #endif
-        || (LIBXSMM_MAX(LIBXSMM_MAX(internal_malloc_public_max, internal_malloc_local_max), internal_malloc_private_max) < result->size
+        || (LIBXSMM_MAX(LIBXSMM_MAX(internal_malloc_public_max, internal_malloc_local_max),
+              internal_malloc_private_max) < result->size
             && 0 == (flags_px & result->flags)) || (0 == result->size)
         || (2 > libxsmm_ninit) /* before checksum calculation */
 #if !defined(LIBXSMM_MALLOC_CRC_OFF) /* last check: checksum over info */
@@ -492,6 +494,11 @@ internal_malloc_info_type* internal_malloc_info(const void* memory, int check)
 # endif
 #endif
       ) { /* mismatch */
+#if !defined(NDEBUG)
+        if (0 != libxsmm_verbosity) { /* library code is expected to be mute */
+          fprintf(stderr, "LIBXSMM ERROR: malloc/free mismatch!\n");
+        }
+#endif
         result = NULL;
       }
     }

--- a/src/libxsmm_perf.c
+++ b/src/libxsmm_perf.c
@@ -10,7 +10,6 @@
 ******************************************************************************/
 #include "libxsmm_perf.h"
 #include <libxsmm_sync.h>
-#include <libxsmm_timer.h>
 
 #include "perf_jitdump.h"
 #if defined(LIBXSMM_PERF_JITDUMP) && !defined(_WIN32)
@@ -59,12 +58,13 @@ LIBXSMM_APIVAR_PRIVATE_DEF(/*const*/ uint32_t JITDUMP_CODE_CLOSE);
 
 LIBXSMM_APIVAR_DEFINE(FILE* internal_perf_fp);
 #if defined(LIBXSMM_PERF_JITDUMP) && !defined(_WIN32)
+LIBXSMM_APIVAR_DEFINE(unsigned long long (*internal_perf_timer)(void));
 LIBXSMM_APIVAR_DEFINE(void* internal_perf_marker);
 LIBXSMM_APIVAR_DEFINE(int internal_perf_codeidx);
 #endif
 
 
-LIBXSMM_API_INTERN void libxsmm_perf_init(void)
+LIBXSMM_API_INTERN void libxsmm_perf_init(unsigned long long (*timer_tick)(void))
 {
   const uint32_t pid = (uint32_t)libxsmm_get_pid();
   char file_name[LIBXSMM_MAX_PATH] = "";
@@ -76,6 +76,9 @@ LIBXSMM_API_INTERN void libxsmm_perf_init(void)
   char date[64];
   time_t t = time(NULL);
   struct tm tm = *localtime(&t);
+
+  LIBXSMM_ASSERT(NULL != timer_tick);
+  internal_perf_timer = timer_tick;
 
   /* initialize global variables */
   JITDUMP_MAGIC = ('J' << 24 | 'i' << 16 | 'T' << 8 | 'D');
@@ -153,7 +156,7 @@ LIBXSMM_API_INTERN void libxsmm_perf_init(void)
   header.elf_mach   = 62;  /* EM_X86_64 */
   header.total_size = sizeof(header);
   header.pid        = pid;
-  header.timestamp  = libxsmm_timer_tick();
+  header.timestamp  = internal_perf_timer();
   header.flags      = JITDUMP_FLAGS_ARCH_TIMESTAMP;
 
   res = fwrite(&header, sizeof(header), 1, internal_perf_fp);
@@ -162,6 +165,7 @@ LIBXSMM_API_INTERN void libxsmm_perf_init(void)
     goto error;
   }
 #else
+  LIBXSMM_UNUSED(timer_tick);
   LIBXSMM_SNPRINTF(file_name, sizeof(file_name), "/tmp/perf-%u.map", pid);
   internal_perf_fp = fopen(file_name, "w+");
   if (internal_perf_fp == NULL) {
@@ -193,7 +197,8 @@ LIBXSMM_API_INTERN void libxsmm_perf_finalize(void)
   LIBXSMM_MEMZERO127(&hdr);
   hdr.id = JITDUMP_CODE_CLOSE;
   hdr.total_size = sizeof(hdr);
-  hdr.timestamp = libxsmm_timer_tick();
+  LIBXSMM_ASSERT(NULL != internal_perf_timer);
+  hdr.timestamp = internal_perf_timer();
   res = fwrite(&hdr, sizeof(hdr), 1, internal_perf_fp);
 
   if (res != 1) {
@@ -232,9 +237,9 @@ LIBXSMM_API_INLINE unsigned int internal_perf_get_tid(void)
 
 LIBXSMM_API_INTERN void libxsmm_perf_dump_code(const void* memory, size_t size, const char* name)
 {
-  assert(internal_perf_fp != NULL);
-  assert(name && *name);
-  assert(memory != NULL && size != 0);
+  LIBXSMM_ASSERT(internal_perf_fp != NULL);
+  LIBXSMM_ASSERT(name != NULL && '\0' != *name);
+  LIBXSMM_ASSERT(memory != NULL && size != 0);
   if (internal_perf_fp != NULL) {
 #if defined(LIBXSMM_PERF_JITDUMP) && !defined(_WIN32)
     int res;
@@ -247,7 +252,8 @@ LIBXSMM_API_INTERN void libxsmm_perf_dump_code(const void* memory, size_t size, 
 
     hdr.id = JITDUMP_CODE_LOAD;
     hdr.total_size = sizeof(hdr) + sizeof(rec) + name_len + size;
-    hdr.timestamp = libxsmm_timer_tick();
+    LIBXSMM_ASSERT(NULL != internal_perf_timer);
+    hdr.timestamp = internal_perf_timer();
 
     rec.code_size = size;
     rec.vma = (uintptr_t) memory;
@@ -270,7 +276,7 @@ LIBXSMM_API_INTERN void libxsmm_perf_dump_code(const void* memory, size_t size, 
     LIBXSMM_FUNLOCK(internal_perf_fp);
     fflush(internal_perf_fp);
 
-    assert(res == 4); /* Expected 4 items written above */
+    LIBXSMM_ASSERT(res == 4); /* Expected 4 items written above */
 #else
     fprintf(internal_perf_fp, "%" PRIxPTR " %lx %s\n", (uintptr_t)memory, (unsigned long)size, name);
     fflush(internal_perf_fp);

--- a/src/libxsmm_perf.h
+++ b/src/libxsmm_perf.h
@@ -14,7 +14,7 @@
 #include <libxsmm_macros.h>
 
 
-LIBXSMM_API_INTERN void libxsmm_perf_init(void);
+LIBXSMM_API_INTERN void libxsmm_perf_init(unsigned long long (*timer_tick)(void));
 LIBXSMM_API_INTERN void libxsmm_perf_finalize(void);
 LIBXSMM_API_INTERN void libxsmm_perf_dump_code(
   const void* memory, size_t size,

--- a/src/libxsmm_xcopy.h
+++ b/src/libxsmm_xcopy.h
@@ -11,7 +11,6 @@
 #ifndef LIBXSMM_XCOPY_H
 #define LIBXSMM_XCOPY_H
 
-#include <libxsmm_typedefs.h>
 #include "libxsmm_main.h"
 
 #if !defined(LIBXSMM_XCOPY_CHECK) && !defined(NDEBUG)

--- a/src/template/libxsmm.f
+++ b/src/template/libxsmm.f
@@ -206,18 +206,6 @@
           SUBROUTINE libxsmm_finalize() BIND(C)
           END SUBROUTINE
 
-          !> Get the default prefetch strategy.
-          PURE FUNCTION libxsmm_get_gemm_auto_prefetch() BIND(C)
-            IMPORT :: C_INT
-            INTEGER(C_INT) :: libxsmm_get_gemm_auto_prefetch
-          END FUNCTION
-
-          !> Set the default prefetch strategy.
-          SUBROUTINE libxsmm_set_gemm_auto_prefetch(strategy) BIND(C)
-            IMPORT :: C_INT
-            INTEGER(C_INT), INTENT(IN), VALUE :: strategy
-          END SUBROUTINE
-
           !> Returns the architecture and instruction set extension
           !> as determined by the CPUID flags, as set by the
           !> libxsmm_get_target_arch* functions, or as set by

--- a/src/template/libxsmm.h
+++ b/src/template/libxsmm.h
@@ -90,11 +90,6 @@ LIBXSMM_API int libxsmm_get_verbosity(void);
  */
 LIBXSMM_API void libxsmm_set_verbosity(int level);
 
-/** Get the default prefetch strategy. */
-LIBXSMM_API libxsmm_gemm_prefetch_type libxsmm_get_gemm_auto_prefetch(void);
-/** Set the default prefetch strategy. */
-LIBXSMM_API void libxsmm_set_gemm_auto_prefetch(libxsmm_gemm_prefetch_type strategy);
-
 /** Get information about the matrix multiplication kernel. */
 LIBXSMM_API int libxsmm_get_mmkernel_info(libxsmm_xmmfunction kernel, libxsmm_mmkernel_info* info);
 /** Get information about the matrix eltwise kernel. */
@@ -158,28 +153,6 @@ LIBXSMM_API libxsmm_dmmfunction libxsmm_dmmdispatch_v2( const libxsmm_blasint m,
 LIBXSMM_API libxsmm_smmfunction libxsmm_smmdispatch_v2( const libxsmm_blasint m, const libxsmm_blasint n, const libxsmm_blasint k,
                                                      const libxsmm_blasint* lda, const libxsmm_blasint* ldb, const libxsmm_blasint* ldc,
                                                      const int* basicflags );
-
-/** Query or JIT-generate SMM-kernel; returns NULL if it does not exist or if JIT is not supported (double-precision). */
-LIBXSMM_API libxsmm_dmmfunction libxsmm_dmmdispatch(libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
-  const libxsmm_blasint* lda, const libxsmm_blasint* ldb, const libxsmm_blasint* ldc,
-  const double* alpha, const double* beta, const int* flags, const int* prefetch);
-/** Query or JIT-generate SMM-kernel; returns NULL if it does not exist or if JIT is not supported (single-precision). */
-LIBXSMM_API libxsmm_smmfunction libxsmm_smmdispatch(libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
-  const libxsmm_blasint* lda, const libxsmm_blasint* ldb, const libxsmm_blasint* ldc,
-  const float* alpha, const float* beta, const int* flags, const int* prefetch);
-
-/** Helper for tuning the given gemm_flags for batches of SMMs (NTS-hint). */
-LIBXSMM_API libxsmm_bitfield libxsmm_gemm_batch_flags(
-  int gemm_flags, const libxsmm_gemm_shape* gemm_shape, const void* c,
-  /**
-   * If the returned value is larger than zero, the vector-length (in Bytes)
-   * is larger than C's element-width and it can be used to check against a
-   * stride of subsequent C-addresses, i.e., there is sufficient alignment
-   * if 0 == LIBXSMM_MOD2(stride_in_byte, *vlen) and the tuned flag
-   * can be adopted.
-   * The vlen argument can be NULL if no further check is desired.
-   */
-  int* vlen);
 
 /**
  * Process a series of SMMs (batch). See also libxsmm_gemm_batch/omp.

--- a/tests/gemmbatch.c
+++ b/tests/gemmbatch.c
@@ -25,10 +25,10 @@
      (defined(LIBXSMM_PLATFORM_X86))
 #   include <mkl.h>
 #   if defined(LIBXSMM_MKL_VERSION3) && (LIBXSMM_VERSION3(2020, 0, 2) <= LIBXSMM_MKL_VERSION3)
-#     define GEMM_BATCH_STRIDED LIBXSMM_TPREFIX(TYPE, gemm_batch_strided)
+#     define GEMM_BATCH_STRIDED LIBXSMM_GEMM_BATCH_STRIDED_SYMBOL(TYPE)
 #   endif
 #   if defined(LIBXSMM_MKL_VERSION2) && (LIBXSMM_VERSION2(11, 3) <= LIBXSMM_MKL_VERSION2)
-#     define GEMM_BATCH LIBXSMM_TPREFIX(TYPE, gemm_batch)
+#     define GEMM_BATCH LIBXSMM_GEMM_BATCH_SYMBOL(TYPE)
 #   endif
 # else
 LIBXSMM_BLAS_SYMBOL_DECL(TYPE, gemm)
@@ -55,8 +55,8 @@ LIBXSMM_BLAS_SYMBOL_DECL(TYPE, gemm)
 #define FREE libxsmm_free
 
 #define EPSILON(T) LIBXSMM_CONCATENATE(EPSILON_, T)
-#define EPSILON_double 1e-12
-#define EPSILON_float 1e-6
+#define EPSILON_double 7e-4
+#define EPSILON_float 7e-2
 
 
 int main(int argc, char* argv[])
@@ -174,8 +174,9 @@ int main(int argc, char* argv[])
 #endif
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -207,8 +208,9 @@ int main(int argc, char* argv[])
 #endif
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -244,8 +246,9 @@ int main(int argc, char* argv[])
 #endif
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -281,8 +284,9 @@ int main(int argc, char* argv[])
 #endif
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -315,8 +319,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -349,8 +354,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -387,8 +393,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -422,8 +429,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -461,8 +469,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -500,8 +509,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -535,8 +545,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -570,8 +581,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -603,8 +615,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -640,8 +653,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -673,8 +687,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -707,8 +722,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -740,8 +756,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -773,8 +790,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -806,8 +824,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -845,8 +864,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -877,8 +897,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -913,8 +934,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -949,8 +971,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -981,8 +1004,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -1013,8 +1037,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -1046,8 +1071,9 @@ int main(int argc, char* argv[])
       libxsmm_matdiff_reduce(&diff, &di);
       result = libxsmm_matdiff(&di, oprec, m, n, d, c, &ldc, &ldc);
       if (EXIT_SUCCESS == result) {
-        FPRINTF(stderr, "Line #%04i error=%f", __LINE__, di.linf_abs);
-        if (EPSILON(TYPE) >= libxsmm_matdiff_epsilon(&di)) {
+        const double epsilon = libxsmm_matdiff_epsilon(&di);
+        FPRINTF(stderr, "Line #%04i abs=%f eps=%f", __LINE__, di.linf_abs, epsilon);
+        if (EPSILON(TYPE) >= epsilon) {
           FPRINTF(stderr, " (%.0f vs %.0f ms)\n", d1 * 1E3, d2 * 1E3);
         }
         else {
@@ -1062,7 +1088,7 @@ int main(int argc, char* argv[])
       double epsilon;
       libxsmm_matdiff_reduce(&diff, &di);
       epsilon = libxsmm_matdiff_epsilon(&diff);
-      FPRINTF(stderr, "Summary    error=%f (%f)", diff.linf_abs, epsilon);
+      FPRINTF(stderr, "Summary    abs=%f eps=%f", diff.linf_abs, epsilon);
       if (EPSILON(TYPE) >= epsilon) FPRINTF(stderr, "\n");
       else {
         FPRINTF(stderr, " (%f != %f)\n", di.v_ref, di.v_tst);

--- a/tests/math.c
+++ b/tests/math.c
@@ -223,21 +223,48 @@ int main(int argc, char* argv[])
     }
   }
 
-  { /* check LIBXSMM_UPDIV, LIBXSMM_UP and LIBXSMM_UP2 */
-    const int ainp[] = { 0, 1, 3, 5, 127, 3000 };
-    const int aout[] = { 0, 1, 1, 1,  19,  429 };
-    const int binp[] = { 0, 1, 3, 5, 127, 3000 };
-    const int bout[] = { 0, 7, 7, 7, 133, 3003 };
-    const int cinp[] = { 0, 7, 8, 9, 127, 3000 };
-    const int cout[] = { 0, 0, 8, 8, 120, 3000 };
-    const int dinp[] = { 0, 1, 3, 5, 127, 3000 };
-    const int dout[] = { 0, 8, 8, 8, 128, 3000 };
-    const int n = sizeof(ainp) / sizeof(*ainp);
+  { /* check LIBXSMM_UPDIV */
+    const int inp[] = { 0, 1, 3, 5, 127, 3000 };
+    const int out[] = { 0, 1, 1, 1,  19,  429 };
+    const int n = sizeof(inp) / sizeof(*inp);
     for (i = 0; i < n; ++i) {
-      if (LIBXSMM_UPDIV(ainp[i], 7) != aout[i]) exit(EXIT_FAILURE);
-      if (LIBXSMM_UP(   binp[i], 7) != bout[i]) exit(EXIT_FAILURE);
-      if (LIBXSMM_LO2(  cinp[i], 8) != cout[i]) exit(EXIT_FAILURE);
-      if (LIBXSMM_UP2(  dinp[i], 8) != dout[i]) exit(EXIT_FAILURE);
+      if (LIBXSMM_UPDIV(inp[i], 7) != out[i]) exit(EXIT_FAILURE);
+    }
+  }
+
+  { /* check LIBXSMM_UP */
+    const int inp[] = { 0, 1, 3, 5, 127, 3000 };
+    const int out[] = { 0, 7, 7, 7, 133, 3003 };
+    const int n = sizeof(inp) / sizeof(*inp);
+    for (i = 0; i < n; ++i) {
+      if (LIBXSMM_UP(inp[i], 7) != out[i]) exit(EXIT_FAILURE);
+    }
+  }
+
+  { /* check LIBXSMM_LO2 */
+    const int inp[] = { 0, 7, 8, 9, 127, 3000 };
+    const int out[] = { 0, 0, 8, 8, 120, 3000 };
+    const int n = sizeof(inp) / sizeof(*inp);
+    for (i = 0; i < n; ++i) {
+      if (LIBXSMM_LO2(inp[i], 8) != out[i]) exit(EXIT_FAILURE);
+    }
+  }
+
+  { /* check LIBXSMM_UP2 */
+    const int inp[] = { 0, 1, 3, 5, 127, 3000 };
+    const int out[] = { 0, 8, 8, 8, 128, 3000 };
+    const int n = sizeof(inp) / sizeof(*inp);
+    for (i = 0; i < n; ++i) {
+      if (LIBXSMM_UP2(inp[i], 8) != out[i]) exit(EXIT_FAILURE);
+    }
+  }
+
+  { /* check LIBXSMM_UPF */
+    const int inp[] = { 0, 1, 3, 5, 127, 3000 };
+    const int out[] = { 0, 1, 3, 5, 130, 3090 };
+    const int n = sizeof(inp) / sizeof(*inp);
+    for (i = 0; i < n; ++i) {
+      if (LIBXSMM_UPF(inp[i], 3, 100) != out[i]) exit(EXIT_FAILURE);
     }
   }
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-main_stable-1.17-3633
+feature_xsmm_v2-1.17-3635


### PR DESCRIPTION
* General
  - Removed macro INTERNAL_PREFETCH, variable internal_gemm_auto_prefetch_locked, and related initialization code.
  - Removed internal functions libxsmm_gemm_prefetch2uid, libxsmm_gemm_prefetch_type libxsmm_gemm_uid2prefetch.
  - Removed internal function libxsmm_get_gemm_xprefetch, and replaced calls with libxsmm_get_gemm_prefetch.
  - Removed helper macros to elide calculating prefetch-address depending on (static) prefetch scheme.
  - Removed libxsmm_get_gemm_auto_prefetch and libxsmm_set_gemm_auto_prefetch (public API).
  - Removed support for environment variable (LIBXSMM_GEMM_PREFETCH).
  - Introduced LIBXSMM_UPF, multiplying an integer by specified fraction (nominator/denominator)
  - Introduced macro LIBXSMM_ARGDEF for function arguments with default value (C++).
  - Removed libxsmm_timer dependency (Linux Perf support).
  - Avoid warning about constant expression. Code cleanup.
  - Introduced warning message (internal_malloc_info).
  - Fixed using enumerator in compile-time condition.
  - Removed variable (libxsmm_gemm_auto_prefetch).
  - Fixed termination statistics (kernel count).
  - Fixed style of including the header file.

* tool_report
  - Split plots into single graphs if untied figure is still only one plot/group.
  - Use median instead of average when calculating historic/relative deviation.
  - Avoid labeling y-axis in a misaligned fashion (multiple plots per page).
  - Adjusted plot style (grid, y-ticks both sides, y-label right).
  - tool_logrept.sh: handle input-format more flexible.
  - Fine-tuned legend entries and code cleanup.

* BLAS interceptor
  - Implemented missing interceptor for dgemm_batch_strided (#642, #740).
  - Completely revised interceptor (avoid certain warnings/fallbacks).

* Tests
  - Split some math tests previously lumped together to be separate per macro/function.
  - Raised margin for external parallelization (tests/gemmbatch).
  - Rely on unwrapped/original symbol (tests/gemmbatch).
  - Fixed BLAS wrapper test to test interception.

* Environment
  - Test directory existence before resolving location.
  - Updated environment (Clang 16.0.4).
  - Improved labeling Slurm jobs.
  - Upload artifact.

* PyFR
  - performance.sh: Fixed referring temporary file (cleanup), and adjusted final output/console format for report.
  - performance.sh: reduced number of iterations, and fixed issues pointed out by Shellcheck.
  - performance.sh: made script artifacts independent of current working directory.
  - performance.sh: opt-in for graphical report (-r|--report).
  - Revised interface and decoupled libxsmm_timer dependency.
  - Test driver: introduced FSSPMDM_NOTUNE for testing purpose.
  - Count number of attempts to create FsSpMDM-handle.
  - tool_test.sh: introduced MAKETGT (Gimmik).


