### PR TITLE
Backported non-breaking fixes and updates from main branch

### DIFF
--- a/.abi.txt
+++ b/.abi.txt
@@ -89,6 +89,7 @@ libxsmm_dmmcall
 libxsmm_dmmcall_abc
 libxsmm_dmmcall_prf
 libxsmm_dmmdispatch
+libxsmm_dmmdispatch_v2
 libxsmm_dsqrt
 libxsmm_dvalue
 libxsmm_finalize
@@ -245,7 +246,6 @@ libxsmm_pfree
 libxsmm_pmalloc
 libxsmm_pmalloc_init
 libxsmm_primes_u32
-libxsmm_print_cmdline
 libxsmm_product_limit
 libxsmm_ptr_b0
 libxsmm_ptr_b1
@@ -327,6 +327,7 @@ libxsmm_smmcall
 libxsmm_smmcall_abc
 libxsmm_smmcall_prf
 libxsmm_smmdispatch
+libxsmm_smmdispatch_v2
 libxsmm_ssqrt
 libxsmm_stdio_acquire
 libxsmm_stdio_release
@@ -336,9 +337,12 @@ libxsmm_strimatch
 libxsmm_stristr
 libxsmm_stristrn
 libxsmm_timer_duration
+libxsmm_timer_duration_rtc
 libxsmm_timer_ncycles
 libxsmm_timer_ncycles_
 libxsmm_timer_tick
+libxsmm_timer_tick_rtc
+libxsmm_timer_tick_tsc
 libxsmm_trace
 libxsmm_trace_finalize
 libxsmm_trace_info

--- a/.theme/requirements.txt
+++ b/.theme/requirements.txt
@@ -1,6 +1,6 @@
 sphinx-rtd-theme
 recommonmark
-mkdocs>=1.4.3
 mistune==0.8.4
+mkdocs
 m2r2
 ford

--- a/include/libxsmm_frontend.h
+++ b/include/libxsmm_frontend.h
@@ -482,13 +482,6 @@
 #define LIBXSMM_MATINIT_OMP(TYPE, SEED, DST, NROWS, NCOLS, LD, SCALE) \
   LIBXSMM_MATINIT_AUX(LIBXSMM_PRAGMA_OMP, TYPE, SEED, DST, NROWS, NCOLS, LD, SCALE)
 
-/**
- * Print the command line arguments of the current process, and get the number of written
- * characters including the prefix, the postfix, but not the terminating NULL character.
- * If zero is returned, nothing was printed (no prefix, no postfix).
- */
-LIBXSMM_API int libxsmm_print_cmdline(FILE* stream, const char* prefix, const char* postfix);
-
 /** Call libxsmm_gemm_print using LIBXSMM's GEMM-flags. */
 #define LIBXSMM_GEMM_PRINT(OSTREAM, PRECISION, FLAGS, M, N, K, DALPHA, A, LDA, B, LDB, DBETA, C, LDC) \
   LIBXSMM_GEMM_PRINT2(OSTREAM, PRECISION, PRECISION, FLAGS, M, N, K, DALPHA, A, LDA, B, LDB, DBETA, C, LDC)

--- a/include/libxsmm_fsspmdm.h
+++ b/include/libxsmm_fsspmdm.h
@@ -26,15 +26,15 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_fsspmdm libxsmm_fsspmdm;
 LIBXSMM_API libxsmm_fsspmdm* libxsmm_fsspmdm_create(libxsmm_datatype datatype,
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
   const void* alpha, const void* beta, const void* a_dense, int LIBXSMM_ARGDEF(c_is_nt, 0),
-  unsigned long long LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
+  libxsmm_timer_tickint LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
 LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
   double alpha, double beta, const double* a_dense, int LIBXSMM_ARGDEF(c_is_nt, 0),
-  unsigned long long LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
+  libxsmm_timer_tickint LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
 LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
   float alpha, float beta, const float* a_dense, int LIBXSMM_ARGDEF(c_is_nt, 0),
-  unsigned long long LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
+  libxsmm_timer_tickint LIBXSMM_ARGDEF((*timer_tick)(void), NULL));
 
 LIBXSMM_API void libxsmm_fsspmdm_execute(const libxsmm_fsspmdm* handle, const void* B, void* C);
 LIBXSMM_API void libxsmm_dfsspmdm_execute(const libxsmm_dfsspmdm* handle, const double* B, double* C);

--- a/include/libxsmm_macros.h
+++ b/include/libxsmm_macros.h
@@ -845,12 +845,12 @@ LIBXSMM_API_INLINE int libxsmm_nonconst_int(int i) { return i; }
 #   endif
 # endif
 #endif
-#if defined(LIBXSMM_BUILD)
+#if defined(LIBXSMM_BUILD) && !defined(_WIN32)
+# if !defined(_XOPEN_SOURCE) && 0
+#   define _XOPEN_SOURCE 500
+# endif
 # if !defined(_DEFAULT_SOURCE)
 #   define _DEFAULT_SOURCE
-# endif
-# if !defined(_XOPEN_SOURCE)
-#   define _XOPEN_SOURCE
 # endif
 # if !defined(_GNU_SOURCE)
 #   define _GNU_SOURCE
@@ -885,13 +885,13 @@ LIBXSMM_API_INLINE int libxsmm_nonconst_int(int i) { return i; }
 # define __has_builtin(A) 0
 #endif
 
-#if (0 != LIBXSMM_SYNC)
-# if defined(_WIN32) || defined(__CYGWIN__)
-#   include <windows.h>
-# else
-#   include <pthread.h>
-#   include <unistd.h>
-# endif
+#if (0 != LIBXSMM_SYNC) && !defined(_WIN32) && !defined(__CYGWIN__)
+# include <pthread.h>
+#endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+# include <windows.h>
+#else
+# include <unistd.h>
 #endif
 #if !defined(LIBXSMM_ASSERT)
 # include <assert.h>

--- a/include/libxsmm_math.h
+++ b/include/libxsmm_math.h
@@ -48,7 +48,12 @@ LIBXSMM_API int libxsmm_matdiff(libxsmm_matdiff_info* info,
   libxsmm_datatype datatype, libxsmm_blasint m, libxsmm_blasint n, const void* ref, const void* tst,
   const libxsmm_blasint* ldref, const libxsmm_blasint* ldtst);
 
-/** Combine absolute and relative norms into a value which can be used to check against a margin. */
+/**
+ * Combine absolute and relative norms into a value which can be used to check against a margin.
+ * A file or directory path given per environment variable LIBXSMM_MATDIFF=/path/to/file stores
+ * the epsilon (followed by a line-break), which can be used to calibrate margins of a test case.
+ * LIBXSMM_MATDIFF can carry optional space-separated arguments used to amend the file entry.
+ */
 LIBXSMM_API double libxsmm_matdiff_epsilon(const libxsmm_matdiff_info* input);
 /**
  * Reduces input into output such that the difference is maintained or increased (max function).
@@ -124,7 +129,7 @@ LIBXSMM_API float libxsmm_sexp2_u8(unsigned char x);
 /**
 * Exponential function (base 2), which is limited to signed 8-bit input values.
 * This function reproduces bit-accurate results (single-precision).
-*/
+ */
 LIBXSMM_API float libxsmm_sexp2_i8(signed char x);
 
 /** Similar to libxsmm_sexp2_i8, but takes an integer as signed 8-bit value (check). */

--- a/include/libxsmm_timer.h
+++ b/include/libxsmm_timer.h
@@ -11,10 +11,8 @@
 #ifndef LIBXSMM_TIMER_H
 #define LIBXSMM_TIMER_H
 
-#include "libxsmm_macros.h"
+#include "libxsmm_typedefs.h"
 
-
-typedef unsigned long long libxsmm_timer_tickint;
 
 LIBXSMM_EXTERN_C typedef struct libxsmm_timer_info {
   int tsc;

--- a/include/libxsmm_typedefs.h
+++ b/include/libxsmm_typedefs.h
@@ -139,6 +139,9 @@
 # endif
 #endif
 
+/** Integer type used to represent tick of a high-resolution timer. */
+typedef unsigned long long libxsmm_timer_tickint;
+
 /** Special type for bitfield flags. */
 typedef unsigned int libxsmm_bitfield;
 

--- a/samples/cp2k/cp2k-dbcsr.cpp
+++ b/samples/cp2k/cp2k-dbcsr.cpp
@@ -196,7 +196,7 @@ int main(int argc, char* argv[])
     { // LAPACK/BLAS3 (reference)
       fprintf(stdout, "LAPACK/BLAS...\n");
       std::fill_n(c, csize, zero);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
 #if defined(_OPENMP)
 #     pragma omp parallel for CP2K_SCHEDULE
 #endif
@@ -228,7 +228,7 @@ int main(int argc, char* argv[])
     { // inline an optimized implementation
       fprintf(stdout, "Inlined...\n");
       std::fill_n(c, csize, zero);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
 #if defined(_OPENMP)
 #     pragma omp parallel for CP2K_SCHEDULE
 #endif
@@ -260,7 +260,7 @@ int main(int argc, char* argv[])
     { // auto-dispatched
       fprintf(stdout, "Dispatched...\n");
       std::fill_n(c, csize, zero);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
 #if defined(_OPENMP)
 #     pragma omp parallel for CP2K_SCHEDULE
 #endif
@@ -292,7 +292,7 @@ int main(int argc, char* argv[])
     if (xmm) { // specialized routine
       fprintf(stdout, "Specialized...\n");
       std::fill_n(c, csize, zero);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
 #if defined(_OPENMP)
 #     pragma omp parallel for CP2K_SCHEDULE
 #endif

--- a/samples/deeplearning/sparse_weight_mult/parallel_sparse_weight_B_conv.c
+++ b/samples/deeplearning/sparse_weight_mult/parallel_sparse_weight_B_conv.c
@@ -369,7 +369,7 @@ int main(int argc, char **argv) {
     printf("max error = %f\n", l_max_error);
 
     /* check performace */
-    unsigned long long l_start = libxsmm_timer_tick();
+    libxsmm_timer_tickint l_start = libxsmm_timer_tick();
     for (i = 0; i < (int)REPS; ++i) {
 #ifdef _OPENMP
 #       pragma omp parallel for LIBXSMM_OPENMP_COLLAPSE(4) private(k,n,c,l_p,l_q,l_h,l_w,l_r,l_s,gemm_param)
@@ -398,7 +398,7 @@ int main(int argc, char **argv) {
         }
       }
     }
-    unsigned long long l_end = libxsmm_timer_tick();
+    libxsmm_timer_tickint l_end = libxsmm_timer_tick();
     double l_total = libxsmm_timer_duration(l_start, l_end);
     printf("%fs for sparse (asm)\n", l_total);
     printf("%f GFLOPS for sparse (asm)\n",

--- a/samples/deeplearning/sparse_weight_mult/parallel_sparse_weight_B_mult.c
+++ b/samples/deeplearning/sparse_weight_mult/parallel_sparse_weight_B_mult.c
@@ -262,7 +262,7 @@ int main(int argc, char **argv) {
     }
     printf("max error = %f\n", l_max_error);
     /* check performace */
-    unsigned long long l_start = libxsmm_timer_tick();
+    libxsmm_timer_tickint l_start = libxsmm_timer_tick();
     for (i = 0; i < (int)REPS; ++i) {
 #ifdef _OPENMP
 #       pragma omp parallel for LIBXSMM_OPENMP_COLLAPSE(2) private(k,n,c,gemm_param)
@@ -279,7 +279,7 @@ int main(int argc, char **argv) {
             }
         }
     }
-    unsigned long long l_end = libxsmm_timer_tick();
+    libxsmm_timer_tickint l_end = libxsmm_timer_tick();
     double l_total = libxsmm_timer_duration(l_start, l_end);
     printf("%fs for sparse (asm)\n", l_total);
     printf("%f GFLOPS for sparse (asm)\n",

--- a/samples/deeplearning/sparse_weight_mult/parallel_sparse_weight_C_redmult.c
+++ b/samples/deeplearning/sparse_weight_mult/parallel_sparse_weight_C_redmult.c
@@ -275,7 +275,7 @@ int main(int argc, char **argv) {
         }
     }
     /* check performace */
-    unsigned long long l_start = libxsmm_timer_tick();
+    libxsmm_timer_tickint l_start = libxsmm_timer_tick();
     for (i = 0; i < REPS; ++i) {
 #ifdef _OPENMP
 #       pragma omp parallel for LIBXSMM_OPENMP_COLLAPSE(2) private(k,n,c,gemm_param)
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
             }
         }
     }
-    unsigned long long l_end = libxsmm_timer_tick();
+    libxsmm_timer_tickint l_end = libxsmm_timer_tick();
     double l_total = libxsmm_timer_duration(l_start, l_end);
     printf("%fs for sparse (asm)\n", l_total);
     printf("%f GFLOPS for sparse (asm)\n",

--- a/samples/deeplearning/sparse_weight_mult/sparse_weight_A_mult.c
+++ b/samples/deeplearning/sparse_weight_mult/sparse_weight_A_mult.c
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
   libxsmm_gemm_param gemm_param;
   libxsmm_gemmfunction mykernel_csr = NULL;
 
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total;
   unsigned int nnz = 0;
 

--- a/samples/deeplearning/sparse_weight_mult/sparse_weight_B_mult.c
+++ b/samples/deeplearning/sparse_weight_mult/sparse_weight_B_mult.c
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
   libxsmm_gemmfunction mykernel_csc = NULL;
   libxsmm_gemmfunction mykernel_csr = NULL;
 
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total;
   unsigned int nnz = 0;
 

--- a/samples/deeplearning/sparse_weight_mult/sparse_weight_C_redmult.c
+++ b/samples/deeplearning/sparse_weight_mult/sparse_weight_C_redmult.c
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
   libxsmm_gemm_param gemm_param;
   libxsmm_gemmfunction mykernel_csc = NULL;
 
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total;
   unsigned int nnz = 0;
 

--- a/samples/edge/asparse_packed_csr.c
+++ b/samples/edge/asparse_packed_csr.c
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 
   libxsmm_kernel_info l_kinfo;
   unsigned long long l_libxsmmflops;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total;
   int result = EXIT_SUCCESS;
 

--- a/samples/edge/bsparse_packed_csc.c
+++ b/samples/edge/bsparse_packed_csc.c
@@ -210,7 +210,7 @@ int main(int argc, char* argv[]) {
 
   libxsmm_kernel_info l_kinfo;
   unsigned long long l_libxsmmflops;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total;
   int result = EXIT_SUCCESS;
 

--- a/samples/edge/bsparse_packed_csr.c
+++ b/samples/edge/bsparse_packed_csr.c
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
 
   libxsmm_kernel_info l_kinfo;
   unsigned long long l_libxsmmflops;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total;
   int result = EXIT_SUCCESS;
 

--- a/samples/eigen/eigen_smm.cpp
+++ b/samples/eigen/eigen_smm.cpp
@@ -134,7 +134,7 @@ int main(int argc, char* argv[])
     switch (benchmark) {
     case 0: if (xmm) {
       fprintf(stdout, "LIBXSMM batched (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
           xmm(ai, bi, ci, ai + asize, bi + bsize, ci + csize);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
 #if defined(__EIGEN)
     case 1: {
       fprintf(stdout, "Eigen/dynamic batched (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
           smm_eigen_dynamic(m, n, k, ai, bi, ci);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
     break;
     case 2: if (xmm) {
       fprintf(stdout, "LIBXSMM streamed (A,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -193,7 +193,7 @@ int main(int argc, char* argv[])
           xmm(ai, b, ci, ai + asize, b, ci + csize);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
 #if defined(__EIGEN)
     case 3: {
       fprintf(stdout, "Eigen/dynamic streamed (A,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -217,7 +217,7 @@ int main(int argc, char* argv[])
           smm_eigen_dynamic(m, n, k, ai, b, ci);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
     break;
     case 4: if (xmm) {
       fprintf(stdout, "LIBXSMM streamed (B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
           xmm(a, bi, ci, a, bi + bsize, ci + csize);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
 #if defined(__EIGEN)
     case 5: {
       fprintf(stdout, "Eigen/dynamic streamed (B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -265,7 +265,7 @@ int main(int argc, char* argv[])
           smm_eigen_dynamic(m, n, k, a, bi, ci);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -278,7 +278,7 @@ int main(int argc, char* argv[])
     break;
     case 6: if (xmm) {
       fprintf(stdout, "LIBXSMM streamed (A,B)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -293,7 +293,7 @@ int main(int argc, char* argv[])
           xmm(ai, bi, c + j, ai + asize, bi + bsize, c + j);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -306,7 +306,7 @@ int main(int argc, char* argv[])
 #if defined(__EIGEN)
     case 7: {
       fprintf(stdout, "Eigen/dynamic streamed (A,B)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
           smm_eigen_dynamic(m, n, k, ai, bi, c + j);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -334,7 +334,7 @@ int main(int argc, char* argv[])
     break;
     case 8: if (xmm) {
       fprintf(stdout, "LIBXSMM cached...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -348,7 +348,7 @@ int main(int argc, char* argv[])
           xmm(a, b, c + j, a, b, c + j);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -360,7 +360,7 @@ int main(int argc, char* argv[])
 #if defined(__EIGEN)
     case 9: {
       fprintf(stdout, "Eigen/dynamic cached...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -374,7 +374,7 @@ int main(int argc, char* argv[])
           smm_eigen_dynamic(m, n, k, a, b, c + j);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);

--- a/samples/eigen/eigen_tensor.cpp
+++ b/samples/eigen/eigen_tensor.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     tensor_type ta(m, k), tb(k, n), tc(m, n);
     LIBXSMM_BLAS_CONST char transa = 'N', transb = 'N';
     LIBXSMM_BLAS_CONST REALTYPE alpha(1), beta(0);
-    unsigned long long start;
+    libxsmm_timer_tickint start
     double d1;
     {
       std::array<Eigen::IndexPair<libxsmm_blasint>,1> product_dims = {

--- a/samples/eltwise/eltwise_opreduce_idxvecs.c
+++ b/samples/eltwise/eltwise_opreduce_idxvecs.c
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
   libxsmm_meltw_opreduce_vecs_flags opredop_flags;
   libxsmm_meltwfunction_opreduce_vecs_idx kernel;
   libxsmm_matdiff_info norms_elts, diff;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0.0, l_total2 = 0.0;
   char opname[50];
   char opordername[50];

--- a/samples/eltwise/eltwise_unary_gather_scatter.c
+++ b/samples/eltwise/eltwise_unary_gather_scatter.c
@@ -474,7 +474,7 @@ int main(int argc, char* argv[])
   libxsmm_meltw_unary_param unary_param;
   int ret = EXIT_FAILURE;
 
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0.0, l_total2 = 0.0;
 
   libxsmm_init();

--- a/samples/eltwise/eltwise_unary_reduce.c
+++ b/samples/eltwise/eltwise_unary_reduce.c
@@ -434,7 +434,7 @@ int main(int argc, char* argv[])
   libxsmm_meltwfunction_unary kernel2 = NULL;
   libxsmm_meltw_unary_param params2;
   libxsmm_matdiff_info norms_elts, norms_elts_squared, diff;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0.0, l_total2 = 0.0;
   unsigned int reduce_on_outputs = 0;
   char* dt = NULL;

--- a/samples/equation/equation_gather_reduce.c
+++ b/samples/equation/equation_gather_reduce.c
@@ -32,7 +32,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_matrix_eqn_function func0;
   libxsmm_blasint i, j,it;
   libxsmm_matrix_eqn_param eqn_param;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0, l_total2 = 0;
   libxsmm_matdiff_info norms_out;
   float *out, *eqn_out;

--- a/samples/equation/equation_layernorm.c
+++ b/samples/equation/equation_layernorm.c
@@ -25,8 +25,6 @@ LIBXSMM_INLINE void _mm512_mask_storeu_ps_auto(libxsmm_bfloat16* mem_addr, __mma
 #endif
 
 
-LIBXSMM_PRAGMA_OPTIMIZE_OFF
-
 LIBXSMM_INLINE
 void vectorized_layernorm_fwd_bf16(long S1, long S2, long S3, libxsmm_bfloat16 *pinp, libxsmm_bfloat16 *pgamma, libxsmm_bfloat16 *pbeta, float *mean, float *var, libxsmm_bfloat16 *pout, float eps) {
   int s1, s2, s3;
@@ -403,8 +401,6 @@ void vectorized_layernorm_bwd_fp32(long S1, long S2, long S3, float *pdout, floa
 #endif
 }
 
-LIBXSMM_PRAGMA_OPTIMIZE_ON
-
 LIBXSMM_INLINE
 void tpp_layernorm_fwd_fp32(long S1, long S2, long S3, float *pinp, float *pgamma, float *pbeta, float *mean, float *var, float *pout, float eps, libxsmm_matrix_eqn_function func0, libxsmm_meltwfunction_unary reduce_rows_kernel, libxsmm_meltwfunction_unary reduce_cols_kernel) {
   int s2;
@@ -607,12 +603,14 @@ int main( int argc, char* argv[] ) {
 
   const float eps = FLT_EPSILON;
   libxsmm_blasint i, it, ld, tmp_ld, tmp_ld2;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0, l_total2 = 0;
   double t_vec = 0, t_tpp = 0;
   libxsmm_matdiff_info norms_out;
   float *inp, *out, *dinp, *dout, *eqn_dinp, *eqn_dout, *dbeta, *eqn_dbeta, *dgamma, *eqn_dgamma, *eqn_out, *gamma, *beta, *cache_fl, *mean, *var;
   libxsmm_bfloat16 *bf16_inp, *bf16_out, *bf16_dinp, *bf16_dout, *bf16_eqn_dinp, *bf16_eqn_dout, *bf16_gamma, *bf16_beta, *bf16_eqn_out;
+  char *matdiff_env;
+  double check_norm;
 #if defined(USE_SUM)
   float sum = 0.0;
 #endif
@@ -622,8 +620,8 @@ int main( int argc, char* argv[] ) {
   int iters = 100;
   int datatype_mode = 0;
   int pass = FWD_BWD_LNORM;
-  libxsmm_datatype  in_dt = LIBXSMM_DATATYPE_F32;
-  libxsmm_datatype  out_dt = LIBXSMM_DATATYPE_F32;
+  libxsmm_datatype in_dt = LIBXSMM_DATATYPE_F32;
+  libxsmm_datatype out_dt = LIBXSMM_DATATYPE_F32;
   libxsmm_meqn_arg_shape arg_shape_out;
 
   libxsmm_init();
@@ -648,6 +646,17 @@ int main( int argc, char* argv[] ) {
     error_bound = LIBXSMM_MAX(0.006, error_bound);
   } else {
     printf("ERROR: Supporting only FP32 and BF16 precisions...\n");
+  }
+
+  /* eventually amend LIBXSMM_MATDIFF output with error bound */
+  matdiff_env = getenv("LIBXSMM_MATDIFF");
+  if (NULL != matdiff_env) {
+    static char matdiff_ext[1024];
+    const int nchars = LIBXSMM_SNPRINTF(matdiff_ext, sizeof(matdiff_ext),
+      "LIBXSMM_MATDIFF=%s %.17g", matdiff_env, error_bound);
+    if (0 < nchars && nchars < (int)sizeof(matdiff_ext)) {
+      LIBXSMM_EXPECT(EXIT_SUCCESS == LIBXSMM_PUTENV(matdiff_ext));
+    }
   }
 
   inp = (float*) libxsmm_aligned_malloc( sizeof(float)*S1*S2*S3,   2097152);
@@ -781,9 +790,10 @@ int main( int argc, char* argv[] ) {
     printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
     printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
     printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+    check_norm = libxsmm_matdiff_epsilon(&norms_out);
+    printf("Check-norm    : %.24f\n\n", check_norm);
 
-    if ( norms_out.normf_rel > error_bound ) {
+    if ( check_norm > error_bound ) {
       ret = EXIT_FAILURE;
     }
 
@@ -987,9 +997,10 @@ int main( int argc, char* argv[] ) {
     printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
     printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
     printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+    check_norm = libxsmm_matdiff_epsilon(&norms_out);
+    printf("Check-norm    : %.24f\n\n", check_norm);
 
-    if ( norms_out.normf_rel > error_bound ) {
+    if ( check_norm > error_bound ) {
       ret = EXIT_FAILURE;
     }
 
@@ -1007,9 +1018,10 @@ int main( int argc, char* argv[] ) {
     printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
     printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
     printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+    check_norm = libxsmm_matdiff_epsilon(&norms_out);
+    printf("Check-norm    : %.24f\n\n", check_norm);
 
-    if ( norms_out.normf_rel > error_bound ) {
+    if ( check_norm > error_bound ) {
       ret = EXIT_FAILURE;
     }
 
@@ -1027,9 +1039,10 @@ int main( int argc, char* argv[] ) {
     printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
     printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
     printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
-    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+    check_norm = libxsmm_matdiff_epsilon(&norms_out);
+    printf("Check-norm    : %.24f\n\n", check_norm);
 
-    if ( norms_out.normf_rel > error_bound ) {
+    if ( check_norm > error_bound ) {
       ret = EXIT_FAILURE;
     }
 

--- a/samples/equation/equation_matmul.c
+++ b/samples/equation/equation_matmul.c
@@ -254,7 +254,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_matrix_eqn_function func0, func1, func2, func3, func4, func5;
   libxsmm_blasint i, j, k, l, it, i2;
   libxsmm_matrix_eqn_param eqn_param;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0, l_total2 = 0;
   libxsmm_matdiff_info norms_out;
   int datatype_mode = 0, iters = 100;

--- a/samples/equation/equation_simple.c
+++ b/samples/equation/equation_simple.c
@@ -319,7 +319,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_matrix_eqn_function func0;
   libxsmm_blasint i, j, s, it;
   libxsmm_matrix_eqn_param eqn_param;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0, l_total2 = 0;
   libxsmm_matdiff_info norms_out;
   float *arg0, *arg1, *arg2, *arg3, *out, *eqn_out;

--- a/samples/equation/equation_softmax.c
+++ b/samples/equation/equation_softmax.c
@@ -427,7 +427,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_blasint my_eqn0, my_eqn2, my_eqn3;
   libxsmm_matrix_eqn_function func0, func2, func3;
   libxsmm_blasint i, it, ld, tmp_ld;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0, l_total2 = 0;
   double t_vec = 0, t_tpp = 0;
   libxsmm_matdiff_info norms_out;

--- a/samples/equation/equation_splitSGD.c
+++ b/samples/equation/equation_splitSGD.c
@@ -126,7 +126,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_matrix_arg arg_array[4];
   libxsmm_matdiff_info norms_out;
   int i, j, it = 0;
-  unsigned long long l_start, l_end;
+  libxsmm_timer_tickint l_start, l_end;
   double l_total = 0, l_total2 = 0;
   int iters = 100;
 

--- a/samples/utilities/smmbench/blas.cpp
+++ b/samples/utilities/smmbench/blas.cpp
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
     switch (benchmark) {
     case 0: { // batched
       fprintf(stdout, "Batched (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -196,13 +196,13 @@ int main(int argc, char* argv[])
   (defined(LIBXSMM_MKL_VERSION2) && (LIBXSMM_VERSION2(11, 3) <= LIBXSMM_MKL_VERSION2))
     case 1: { // batched indirect
       fprintf(stdout, "Indirect (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         LIBXSMM_BLAS_FUNCTION(ITYPE,OTYPE,gemm_batch)(&transa, &transb, &m, &n, &k,
           &alpha, &a_array[0], &lda, &b_array[0], &ldb,
             &beta, &c_array[0], &ldc, &group_count, &s);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
     break;
     case 2: { // streaming A and C
       fprintf(stdout, "Streamed (A,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -260,13 +260,13 @@ int main(int argc, char* argv[])
         b_array[i] = b;
         c_array[i] = d + static_cast<size_t>(csize) * i;
       }
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         LIBXSMM_BLAS_FUNCTION(ITYPE,OTYPE,gemm_batch)(&transa, &transb, &m, &n, &k,
           &alpha, &a_array[0], &lda, &b_array[0], &ldb,
             &beta, &c_array[0], &ldc, &group_count, &s);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -294,7 +294,7 @@ int main(int argc, char* argv[])
     break;
     case 4: { // streaming B and C
       fprintf(stdout, "Streamed (B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -305,7 +305,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -324,13 +324,13 @@ int main(int argc, char* argv[])
         b_array[i] = b + static_cast<size_t>(bsize) * helper.shuffle(i);
         c_array[i] = d + static_cast<size_t>(csize) * i;
       }
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         LIBXSMM_BLAS_FUNCTION(ITYPE,OTYPE,gemm_batch)(&transa, &transb, &m, &n, &k,
           &alpha, &a_array[0], &lda, &b_array[0], &ldb,
             &beta, &c_array[0], &ldc, &group_count, &s);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
     break;
     case 6: { // streaming A and B
       fprintf(stdout, "Streamed (A,B)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for num_threads(0 == check ? nthreads : 1) schedule(static)
@@ -373,7 +373,7 @@ int main(int argc, char* argv[])
               &beta, c + j, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -404,13 +404,13 @@ int main(int argc, char* argv[])
 #if defined(_OPENMP)
       omp_set_num_threads(0 == check ? nthreads : 1);
 #endif
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         LIBXSMM_BLAS_FUNCTION(ITYPE,OTYPE,gemm_batch)(&transa, &transb, &m, &n, &k,
           &alpha, &a_array[0], &lda, &b_array[0], &ldb,
             &beta, &c_array[0], &ldc, &group_count, &s);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -432,7 +432,7 @@ int main(int argc, char* argv[])
     break;
     case 8: { // cached
       fprintf(stdout, "Cached...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for num_threads(0 == check ? nthreads : 1) schedule(static)
@@ -446,7 +446,7 @@ int main(int argc, char* argv[])
             &alpha, a, &lda, b, &ldb, &beta, c + j, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -475,13 +475,13 @@ int main(int argc, char* argv[])
 #if defined(_OPENMP)
       omp_set_num_threads(0 == check ? nthreads : 1);
 #endif
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         LIBXSMM_BLAS_FUNCTION(ITYPE,OTYPE,gemm_batch)(&transa, &transb, &m, &n, &k,
           &alpha, &a_array[0], &lda, &b_array[0], &ldb,
             &beta, &c_array[0], &ldc, &group_count, &s);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);

--- a/samples/utilities/smmbench/dispatched.cpp
+++ b/samples/utilities/smmbench/dispatched.cpp
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     switch (benchmark) {
     case 0: { // batched
       fprintf(stdout, "Batched (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for schedule(static)
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -144,7 +144,7 @@ int main(int argc, char* argv[])
 
     case 1: { // streaming A and C
       fprintf(stdout, "Streamed (A,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for schedule(static)
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -167,7 +167,7 @@ int main(int argc, char* argv[])
 
     case 2: { // streaming B and C
       fprintf(stdout, "Streamed (B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for schedule(static)
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -190,7 +190,7 @@ int main(int argc, char* argv[])
 
     case 3: { // streaming A and B
       fprintf(stdout, "Streamed (A,B)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for schedule(static)
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
               &beta, c + j, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
 
     case 4: { // cached
       fprintf(stdout, "Cached...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #         pragma omp parallel for schedule(static)
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
               &beta, c + j, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);

--- a/samples/utilities/smmbench/inlined.cpp
+++ b/samples/utilities/smmbench/inlined.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
     switch (benchmark) {
     case 0: { // batched
       fprintf(stdout, "Batched (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
 
     case 1: { // streaming A and C
       fprintf(stdout, "Streamed (A,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
 
     case 2: { // streaming B and C
       fprintf(stdout, "Streamed (B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
               &beta, c + static_cast<size_t>(csize) * i, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -186,7 +186,7 @@ int main(int argc, char* argv[])
 
     case 3: { // streaming A and B
       fprintf(stdout, "Streamed (A,B)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
               &beta, c + j, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -214,7 +214,7 @@ int main(int argc, char* argv[])
 
     case 4: { // cached
       fprintf(stdout, "Cached...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for schedule(static)
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
               &beta, c + j, &ldc);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);

--- a/samples/utilities/smmbench/specialized.cpp
+++ b/samples/utilities/smmbench/specialized.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
     switch (benchmark) {
     case 0: { // batched
       fprintf(stdout, "Batched (A,B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
           xmm(ai, bi, ci);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -164,13 +164,13 @@ int main(int argc, char* argv[])
         c_array[i] = d + static_cast<size_t>(csize) * i;
       }
       const libxsmm_blasint ptrsize = sizeof(void*);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         USEOMP(libxsmm_gemm_batch)(LIBXSMM_DATATYPE(ITYPE), LIBXSMM_DATATYPE(OTYPE), &transa, &transb, m, n, k,
           &alpha, &a_array[0], &lda, &ptrsize, &b_array[0], &ldb, &ptrsize, &beta, &c_array[0], &ldc, &ptrsize,
           0/*index_stride*/, 0/*index_base*/, s, 0/*batchcheck*/);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -197,7 +197,7 @@ int main(int argc, char* argv[])
 
     case 2: { // streaming A and C
       fprintf(stdout, "Streamed (A,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -208,7 +208,7 @@ int main(int argc, char* argv[])
           xmm(ai, b, ci);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -226,13 +226,13 @@ int main(int argc, char* argv[])
         c_array[i] = d + static_cast<size_t>(csize) * i;
       }
       const libxsmm_blasint ptrsize = sizeof(void*);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         USEOMP(libxsmm_gemm_batch)(LIBXSMM_DATATYPE(ITYPE), LIBXSMM_DATATYPE(OTYPE), &transa, &transb, m, n, k,
           &alpha, &a_array[0], &lda, &ptrsize, &b_array[0], &ldb, &ptrsize, &beta, &c_array[0], &ldc, &ptrsize,
           0/*index_stride*/, 0/*index_base*/, s, 0/*batchcheck*/);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -259,7 +259,7 @@ int main(int argc, char* argv[])
 
     case 4: { // streaming B and C
       fprintf(stdout, "Streamed (B,C)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -270,7 +270,7 @@ int main(int argc, char* argv[])
           xmm(a, bi, ci);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -288,13 +288,13 @@ int main(int argc, char* argv[])
         c_array[i] = d + static_cast<size_t>(csize) * i;
       }
       const libxsmm_blasint ptrsize = sizeof(void*);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         USEOMP(libxsmm_gemm_batch)(LIBXSMM_DATATYPE(ITYPE), LIBXSMM_DATATYPE(OTYPE), &transa, &transb, m, n, k,
           &alpha, &a_array[0], &lda, &ptrsize, &b_array[0], &ldb, &ptrsize, &beta, &c_array[0], &ldc, &ptrsize,
           0/*index_stride*/, 0/*index_base*/, s, 0/*batchcheck*/);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
 
     case 6: { // streaming A and B
       fprintf(stdout, "Streamed (A,B)...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for num_threads(0 == check ? nthreads : 1) schedule(static)
@@ -335,7 +335,7 @@ int main(int argc, char* argv[])
           xmm(ai, bi, c + j);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -362,13 +362,13 @@ int main(int argc, char* argv[])
         c_array[i] = d;
       }
       const libxsmm_blasint ptrsize = sizeof(void*);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         USEOMP(libxsmm_gemm_batch)(LIBXSMM_DATATYPE(ITYPE), LIBXSMM_DATATYPE(OTYPE), &transa, &transb, m, n, k,
           &alpha, &a_array[0], &lda, &ptrsize, &b_array[0], &ldb, &ptrsize, &beta, &c_array[0], &ldc, &ptrsize,
           0/*index_stride*/, 0/*index_base*/, 0 == check ? -s : s, 0/*batchcheck*/);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -389,7 +389,7 @@ int main(int argc, char* argv[])
 
     case 8: { // cached
       fprintf(stdout, "Cached...\n");
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
 #if defined(_OPENMP)
 #       pragma omp parallel for num_threads(0 == check ? nthreads : 1) schedule(static)
@@ -402,7 +402,7 @@ int main(int argc, char* argv[])
           xmm(a, b, c + j);
         }
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);
@@ -427,13 +427,13 @@ int main(int argc, char* argv[])
         c_array[i] = d;
       }
       const libxsmm_blasint ptrsize = sizeof(void*);
-      const unsigned long long start = libxsmm_timer_tick();
+      const libxsmm_timer_tickint start = libxsmm_timer_tick();
       for (libxsmm_blasint r = 0; r < nrepeat; ++r) {
         USEOMP(libxsmm_gemm_batch)(LIBXSMM_DATATYPE(ITYPE), LIBXSMM_DATATYPE(OTYPE), &transa, &transb, m, n, k,
           &alpha, &a_array[0], &lda, &ptrsize, &b_array[0], &ldb, &ptrsize, &beta, &c_array[0], &ldc, &ptrsize,
           0/*index_stride*/, 0/*index_base*/, 0 == check ? -s : s, 0/*batchcheck*/);
       }
-      const unsigned long long ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
+      const libxsmm_timer_tickint ncycles = libxsmm_timer_ncycles(start, libxsmm_timer_tick());
       const double duration = libxsmm_timer_duration(0, ncycles) / nrepeat;
       if (0 < duration && 0 != ncycles) {
         fprintf(stdout, "\tpseudo-perf.: %.1f %s/cycle\n", (2.0 * k - 1.0) * (static_cast<double>(s) * m * n) / ncycles, ops);

--- a/samples/xgemm/gemm_kernel.c
+++ b/samples/xgemm/gemm_kernel.c
@@ -1717,7 +1717,7 @@ void print_help(void) {
   printf("    0: A normal, 1: A vnni\n");
   printf("    0: B normal, 1: B vnni\n");
   printf("    0: C normal, 1: C vnni\n");
-  printf("    PREFETCH: nopf (none), pfsigonly, BL2viaC, AL2, curAL2, AL2_BL2viaC, curAL2_BL2viaC\n");
+  printf("    PREFETCH: nopf (none), BL2viaC, AL2, curAL2, AL2_BL2viaC, curAL2_BL2viaC\n");
   printf("    BRGEMM: nobr, addrbr, offsbr, strdbr\n");
   printf("    BRsize: 1 - N\n");
   printf("    BRunroll: 0/1\n");

--- a/src/libxsmm_cpuid_x86.c
+++ b/src/libxsmm_cpuid_x86.c
@@ -76,7 +76,6 @@
 LIBXSMM_API_INTERN int libxsmm_cpuid_x86_amx_enable(void);
 # if defined(__linux__)
 #  include <sys/syscall.h>
-#  include <unistd.h>
 #  if !defined(LIBXSMM_BUILD) || (1 >= (LIBXSMM_BUILD))
 LIBXSMM_EXTERN long syscall(long number, ...) LIBXSMM_NOTHROW;
 #  endif

--- a/src/libxsmm_fsspmdm.c
+++ b/src/libxsmm_fsspmdm.c
@@ -23,7 +23,7 @@
 
 LIBXSMM_API libxsmm_fsspmdm* libxsmm_fsspmdm_create(libxsmm_datatype datatype,
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
-  const void* alpha, const void* beta, const void* a_dense, int c_is_nt, unsigned long long (*timer_tick)(void))
+  const void* alpha, const void* beta, const void* a_dense, int c_is_nt, libxsmm_timer_tickint (*timer_tick)(void))
 {
   libxsmm_bitfield flags = LIBXSMM_GEMM_FLAGS('N', 'N');
   libxsmm_bitfield prefetch_flags = LIBXSMM_GEMM_PREFETCH_NONE;
@@ -274,12 +274,12 @@ LIBXSMM_API libxsmm_fsspmdm* libxsmm_fsspmdm_create(libxsmm_datatype datatype,
   /* We have at least one kernel */
   if (0 < nkerns) {
     void *B = NULL, *C = NULL;
-    unsigned long long dt_sparse1 = (unsigned long long)-1;
-    unsigned long long dt_sparse2 = (unsigned long long)-1;
-    unsigned long long dt_sparse4 = (unsigned long long)-1;
-    unsigned long long dt_dense = (unsigned long long)-1;
+    libxsmm_timer_tickint dt_sparse1 = (libxsmm_timer_tickint)-1;
+    libxsmm_timer_tickint dt_sparse2 = (libxsmm_timer_tickint)-1;
+    libxsmm_timer_tickint dt_sparse4 = (libxsmm_timer_tickint)-1;
+    libxsmm_timer_tickint dt_dense = (libxsmm_timer_tickint)-1;
     libxsmm_gemm_param gemm_param;
-    unsigned long long s, t;
+    libxsmm_timer_tickint s, t;
 
     /* Run benchmark if there are at least two kernels and a timer routine */
     if (2 <= nkerns && NULL != timer_tick) {
@@ -471,7 +471,7 @@ LIBXSMM_API libxsmm_fsspmdm* libxsmm_fsspmdm_create(libxsmm_datatype datatype,
 
 LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
-  double alpha, double beta, const double* a_dense, int c_is_nt, unsigned long long (*timer_tick)(void))
+  double alpha, double beta, const double* a_dense, int c_is_nt, libxsmm_timer_tickint (*timer_tick)(void))
 {
   return libxsmm_fsspmdm_create(LIBXSMM_DATATYPE_F64, M, N, K, lda, ldb, ldc, &alpha, &beta, a_dense, c_is_nt, timer_tick);
 }
@@ -479,7 +479,7 @@ LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
 
 LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K, libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
-  float alpha, float beta, const float* a_dense, int c_is_nt, unsigned long long (*timer_tick)(void))
+  float alpha, float beta, const float* a_dense, int c_is_nt, libxsmm_timer_tickint (*timer_tick)(void))
 {
   return libxsmm_fsspmdm_create(LIBXSMM_DATATYPE_F32, M, N, K, lda, ldb, ldc, &alpha, &beta, a_dense, c_is_nt, timer_tick);
 }

--- a/src/libxsmm_generator_gemm_driver.c
+++ b/src/libxsmm_generator_gemm_driver.c
@@ -28,7 +28,7 @@ LIBXSMM_INLINE void print_help(void) {
   printf("    0: unaligned A, otherwise aligned (ignored for sparse)\n");
   printf("    0: unaligned C, otherwise aligned (ignored for sparse)\n");
   printf("    ARCH: noarch, wsm, snb, hsw, knl, knm, skx, clx, cpx\n");
-  printf("    PREFETCH: nopf (none), pfsigonly, other options fallback to pfsigonly\n");
+  printf("    PREFETCH: nopf (none), other options are not supported\n");
   printf("    PRECISION: SP, DP\n");
   printf("    matrix input (CSC mtx file)\n");
   printf("\n\n");
@@ -47,7 +47,7 @@ LIBXSMM_INLINE void print_help(void) {
   printf("    0: unaligned A, otherwise aligned\n");
   printf("    0: unaligned C, otherwise aligned\n");
   printf("    ARCH: noarch, wsm, snb, hsw, knl, knm, skx, clx, cpx\n");
-  printf("    PREFETCH: nopf (none), pfsigonly, BL2viaC, AL2, curAL2,\n"
+  printf("    PREFETCH: nopf (none), BL2viaC, AL2, curAL2,\n"
          "              AL2_BL2viaC, curAL2_BL2viaC,\n");
   printf("    PRECISION: SP, DP\n");
   printf("\n\n\n\n");

--- a/src/libxsmm_main.h
+++ b/src/libxsmm_main.h
@@ -122,6 +122,21 @@
 # endif
 #endif
 
+#if defined(__powerpc64__)
+# define LIBXSMM_TIMER_RDTSC(CYCLE) do { \
+    CYCLE = __ppc_get_timebase(); \
+  } while(0)
+#elif ((defined(LIBXSMM_PLATFORM_X86) && (64 <= (LIBXSMM_BITS))) && \
+      (defined(__GNUC__) || defined(LIBXSMM_INTEL_COMPILER) || defined(__PGI)))
+# define LIBXSMM_TIMER_RDTSC(CYCLE) do { \
+    libxsmm_timer_tickint libxsmm_timer_rdtsc_hi_; \
+    __asm__ __volatile__ ("rdtsc" : "=a"(CYCLE), "=d"(libxsmm_timer_rdtsc_hi_)); \
+    CYCLE |= libxsmm_timer_rdtsc_hi_ << 32; \
+  } while(0)
+#elif (defined(_rdtsc) || defined(_WIN32)) && defined(LIBXSMM_PLATFORM_X86)
+# define LIBXSMM_TIMER_RDTSC(CYCLE) (CYCLE = __rdtsc())
+#endif
+
 #if !defined(LIBXSMM_VERBOSITY_HIGH)
 # define LIBXSMM_VERBOSITY_HIGH 3 /* secondary warning or info-verbosity */
 #endif
@@ -131,19 +146,6 @@
 
 #if !defined(LIBXSMM_LOCK)
 # define LIBXSMM_LOCK LIBXSMM_LOCK_DEFAULT
-#endif
-
-#if !defined(LIBXSMM_EXT_MIN_NTASKS)
-# define LIBXSMM_MIN_NTASKS(NT) 1
-#endif
-#if !defined(LIBXSMM_OVERHEAD)
-# define LIBXSMM_OVERHEAD(NT) 0
-#endif
-#if !defined(LIBXSMM_NOOP_ARGS)
-# define LIBXSMM_NOOP_ARGS(...)
-#endif
-#if !defined(LIBXSMM_NOOP)
-# define LIBXSMM_NOOP
 #endif
 
 /** Check if M, N, K, or LDx fits into the descriptor. */
@@ -169,7 +171,7 @@
     /*if (LIBXSMM_GEMM_FLAG_DESC_ISBIG <= (FLAGS)) LIBXSMM_MEMSET127(DST, 0, SIZE)*/
 #endif
 #else
-#define LIBXSMM_DESCRIPTOR_CLEAR_AUX(DST, SIZE, FLAGS) LIBXSMM_MEMSET127(DST, 0, SIZE)
+# define LIBXSMM_DESCRIPTOR_CLEAR_AUX(DST, SIZE, FLAGS) LIBXSMM_MEMSET127(DST, 0, SIZE)
 #endif
 #define LIBXSMM_DESCRIPTOR_CLEAR(BLOB) \
   LIBXSMM_ASSERT((LIBXSMM_DESCRIPTOR_MAXSIZE) == sizeof(*(BLOB))); \
@@ -503,6 +505,14 @@ LIBXSMM_API_INTERN size_t libxsmm_format_value(char buffer[32],
   int buffer_size, size_t nbytes, const char scale[], const char* unit, int base);
 
 /**
+ * Print the command line arguments of the current process, and get the number of written
+ * characters including the prefix, the postfix, but not the terminating NULL character.
+ * If zero is returned, nothing was printed (no prefix, no postfix).
+ * If buffer_size is zero, buffer is assumed to be a FILE-pointer.
+ */
+LIBXSMM_API_INTERN int libxsmm_print_cmdline(void* buffer, size_t buffer_size, const char* prefix, const char* postfix);
+
+/**
  * Dump data, (optionally) check attempt to dump different data into an existing file (unique),
  * or (optionally) permit overwriting an existing file.
  */
@@ -525,11 +535,11 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_kernel_xinfo {
 LIBXSMM_API_INTERN const libxsmm_kernel_xinfo* libxsmm_get_kernel_xinfo(libxsmm_code_pointer code, const libxsmm_descriptor** desc, size_t* code_size);
 
 /** Calculates duration in seconds from given RTC ticks. */
-LIBXSMM_API_INTERN double libxsmm_timer_duration_rtc(libxsmm_timer_tickint tick0, libxsmm_timer_tickint tick1);
+LIBXSMM_API double libxsmm_timer_duration_rtc(libxsmm_timer_tickint tick0, libxsmm_timer_tickint tick1);
 /** Returns the current tick of platform-specific real-time clock. */
-LIBXSMM_API_INTERN libxsmm_timer_tickint libxsmm_timer_tick_rtc(void);
+LIBXSMM_API libxsmm_timer_tickint libxsmm_timer_tick_rtc(void);
 /** Returns the current tick of a (monotonic) platform-specific counter. */
-LIBXSMM_API_INTERN libxsmm_timer_tickint libxsmm_timer_tick_tsc(void);
+LIBXSMM_API libxsmm_timer_tickint libxsmm_timer_tick_tsc(void);
 
 LIBXSMM_API_INTERN void libxsmm_memory_init(int target_arch);
 LIBXSMM_API_INTERN void libxsmm_memory_finalize(void);

--- a/src/libxsmm_malloc.c
+++ b/src/libxsmm_malloc.c
@@ -24,7 +24,6 @@
 # endif
 #endif
 #if defined(_WIN32)
-# include <windows.h>
 # include <malloc.h>
 # include <intrin.h>
 #else
@@ -38,7 +37,6 @@
 # endif
 # include <sys/types.h>
 # include <sys/stat.h>
-# include <unistd.h>
 # include <errno.h>
 # if defined(__MAP_ANONYMOUS)
 #   define LIBXSMM_MAP_ANONYMOUS __MAP_ANONYMOUS

--- a/src/libxsmm_perf.c
+++ b/src/libxsmm_perf.c
@@ -25,7 +25,6 @@
 # include <syscall.h>
 #endif
 #if defined(_WIN32)
-# include <windows.h>
 # define LIBXSMM_MAX_PATH MAX_PATH
 #else
 # if defined(__linux__)
@@ -36,7 +35,6 @@
 # else /* fallback */
 #   define LIBXSMM_MAX_PATH 1024
 # endif
-# include <unistd.h>
 #endif
 
 #if !defined(NDEBUG)
@@ -58,13 +56,13 @@ LIBXSMM_APIVAR_PRIVATE_DEF(/*const*/ uint32_t JITDUMP_CODE_CLOSE);
 
 LIBXSMM_APIVAR_DEFINE(FILE* internal_perf_fp);
 #if defined(LIBXSMM_PERF_JITDUMP) && !defined(_WIN32)
-LIBXSMM_APIVAR_DEFINE(unsigned long long (*internal_perf_timer)(void));
+LIBXSMM_APIVAR_DEFINE(libxsmm_timer_tickint (*internal_perf_timer)(void));
 LIBXSMM_APIVAR_DEFINE(void* internal_perf_marker);
 LIBXSMM_APIVAR_DEFINE(int internal_perf_codeidx);
 #endif
 
 
-LIBXSMM_API_INTERN void libxsmm_perf_init(unsigned long long (*timer_tick)(void))
+LIBXSMM_API_INTERN void libxsmm_perf_init(libxsmm_timer_tickint (*timer_tick)(void))
 {
   const uint32_t pid = (uint32_t)libxsmm_get_pid();
   char file_name[LIBXSMM_MAX_PATH] = "";

--- a/src/libxsmm_perf.h
+++ b/src/libxsmm_perf.h
@@ -11,10 +11,10 @@
 #ifndef LIBXSMM_PERF_H
 #define LIBXSMM_PERF_H
 
-#include <libxsmm_macros.h>
+#include <libxsmm_typedefs.h>
 
 
-LIBXSMM_API_INTERN void libxsmm_perf_init(unsigned long long (*timer_tick)(void));
+LIBXSMM_API_INTERN void libxsmm_perf_init(libxsmm_timer_tickint (*timer_tick)(void));
 LIBXSMM_API_INTERN void libxsmm_perf_finalize(void);
 LIBXSMM_API_INTERN void libxsmm_perf_dump_code(
   const void* memory, size_t size,

--- a/src/libxsmm_sync.c
+++ b/src/libxsmm_sync.c
@@ -22,7 +22,6 @@
 # if defined(LIBXSMM_SYNC_FUTEX) && defined(__linux__) && defined(__USE_GNU)
 #   include <linux/futex.h>
 # endif
-# include <unistd.h>
 # include <time.h>
 #endif
 

--- a/src/libxsmm_timer.c
+++ b/src/libxsmm_timer.c
@@ -11,102 +11,11 @@
 #include <libxsmm_timer.h>
 #include "libxsmm_main.h"
 
-#if defined(_WIN32)
-# include <Windows.h>
-#elif defined(__GNUC__) || defined(__PGI) || defined(_CRAYC)
-# include <sys/time.h>
-# include <time.h>
-#endif
-
-#if defined(__powerpc64__)
-# include <sys/platform/ppc.h>
-#endif
-
 #if !defined(LIBXSMM_TIMER_VERBOSE) && !defined(NDEBUG)
 # if !defined(LIBXSMM_PLATFORM_AARCH64) || !defined(__APPLE__)
 #   define LIBXSMM_TIMER_VERBOSE
 # endif
 #endif
-#if !defined(LIBXSMM_TIMER_TSC)
-# define LIBXSMM_TIMER_TSC
-#endif
-#if !defined(LIBXSMM_TIMER_WPC)
-# define LIBXSMM_TIMER_WPC
-#endif
-
-#if defined(LIBXSMM_TIMER_TSC)
-# if defined(__powerpc64__)
-#   define LIBXSMM_TIMER_RDTSC(CYCLE) do { \
-      CYCLE = __ppc_get_timebase(); \
-    } while(0)
-# elif ((defined(LIBXSMM_PLATFORM_X86) && (64 <= (LIBXSMM_BITS))) && \
-        (defined(__GNUC__) || defined(LIBXSMM_INTEL_COMPILER) || defined(__PGI)))
-#   define LIBXSMM_TIMER_RDTSC(CYCLE) do { \
-      libxsmm_timer_tickint libxsmm_timer_rdtsc_hi_; \
-      __asm__ __volatile__ ("rdtsc" : "=a"(CYCLE), "=d"(libxsmm_timer_rdtsc_hi_)); \
-      CYCLE |= libxsmm_timer_rdtsc_hi_ << 32; \
-    } while(0)
-# elif (defined(_rdtsc) || defined(_WIN32)) && defined(LIBXSMM_PLATFORM_X86)
-#   define LIBXSMM_TIMER_RDTSC(CYCLE) (CYCLE = __rdtsc())
-# endif
-#endif
-
-
-LIBXSMM_API_INTERN double libxsmm_timer_duration_rtc(libxsmm_timer_tickint tick0, libxsmm_timer_tickint tick1)
-{
-  double result = (double)LIBXSMM_DELTA(tick0, tick1);
-#if defined(_WIN32)
-# if defined(LIBXSMM_TIMER_WPC)
-  LARGE_INTEGER frequency;
-  QueryPerformanceFrequency(&frequency);
-  result /= (double)frequency.QuadPart;
-# else /* low resolution */
-  result *= 1E-3;
-# endif
-#elif defined(CLOCK_MONOTONIC)
-  result *= 1E-9;
-#else
-  result *= 1E-6;
-#endif
-  return result;
-}
-
-
-LIBXSMM_API_INTERN libxsmm_timer_tickint libxsmm_timer_tick_rtc(void)
-{
-  libxsmm_timer_tickint result;
-#if defined(_WIN32)
-# if defined(LIBXSMM_TIMER_WPC)
-  LARGE_INTEGER t;
-  QueryPerformanceCounter(&t);
-  result = (libxsmm_timer_tickint)t.QuadPart;
-# else /* low resolution */
-  result = (libxsmm_timer_tickint)GetTickCount64();
-# endif
-#elif defined(CLOCK_MONOTONIC)
-  struct timespec t;
-  clock_gettime(CLOCK_MONOTONIC, &t);
-  result = 1000000000ULL * t.tv_sec + t.tv_nsec;
-#else
-  struct timeval t;
-  gettimeofday(&t, 0);
-  result = 1000000ULL * t.tv_sec + t.tv_usec;
-#endif
-  return result;
-}
-
-
-LIBXSMM_API_INTERN LIBXSMM_INTRINSICS(LIBXSMM_X86_GENERIC)
-libxsmm_timer_tickint libxsmm_timer_tick_tsc(void)
-{
-  libxsmm_timer_tickint result;
-#if defined(LIBXSMM_TIMER_RDTSC)
-  LIBXSMM_TIMER_RDTSC(result);
-#else
-  result = libxsmm_timer_tick_rtc();
-#endif
-  return result;
-}
 
 
 LIBXSMM_API int libxsmm_get_timer_info(libxsmm_timer_info* info)

--- a/src/libxsmm_trace.c
+++ b/src/libxsmm_trace.c
@@ -52,8 +52,6 @@ LIBXSMM_APIVAR_DEFINE(volatile int internal_trace_initialized);
 # else
 #   include <sys/stat.h>
 #   include <sys/mman.h>
-#   include <unistd.h>
-#   include <pthread.h>
 #   include <fcntl.h>
 #   if (0 != LIBXSMM_SYNC)
 LIBXSMM_APIVAR_DEFINE(LIBXSMM_TLS_TYPE internal_trace_key);

--- a/tests/timer.c
+++ b/tests/timer.c
@@ -21,12 +21,6 @@
 # define MAX_TOLPERC 12
 #endif
 
-#if defined(_WIN32)
-# include <Windows.h>
-#else
-# include <unistd.h>
-#endif
-
 
 LIBXSMM_INLINE int timer_sleep(unsigned int seconds)
 {


### PR DESCRIPTION
* General changes
  - Implemented libxsmm_print_cmdline to allow file-output and output into a string-buffer.
  - Disabled defining _XOPEN_SOURCE even when internalized by LIBXSMM_BUILD (evil).
  - Removed some superfluous include directives (already included by libxsmm_macros.h).
  - Removed some unused/cumbersome/legacy macros (libxsmm_main.h).
  - Renamed INTERNAL_DELIMS to LIBXSMM_MAIN_DELIMS.
  - Updated ABI specification.

* libxsmm_matdiff_epsilon: introduced environment variable LIBXSMM_MATDIFF implemented by libxsmm_matdiff_epsilon.
  - A file or directory path like LIBXSMM_MATDIFF=/path/to/file stores the epsilon (followed by a line-break),
     which can be used to calibrate margins of a test case.
  - LIBXSMM_MATDIFF can carry an optional space-separated argument used to amend the file entry,
     which is demonstrated by equation_layernorm.c as well.
  - Print command-line into LIBXSMM_MATDIFF-log.

* Equation test (layer norm)
  - Removed LIBXSMM_PRAGMA_OPTIMIZE_OFF/LIBXSMM_PRAGMA_OPTIMIZE_ON.
  - Make use of libxsmm_matdiff_epsilon (equation_layernorm.c).

* libxsmm_timer: prepared for removing timer API from main library
  - Published libxsmm_timer_duration_rtc, libxsmm_timer_tick_rtc, and libxsmm_timer_tick_tsc.
  - Updated several tests to use libxsmm_timer_tickint (libxsmm_typedefs.h) instead of plain unsigned long long.
  - Removed internal compile-time options (LIBXSMM_TIMER_TSC, LIBXSMM_TIMER_WPC).
  - Moved type-definition of libxsmm_timer_tickint into libxsmm_typedefs.h.