### PR TITLE
Issue #790: restore error bounds/logic

### DIFF
--- a/samples/eltwise/eltwise_opreduce_idxvecs.c
+++ b/samples/eltwise/eltwise_opreduce_idxvecs.c
@@ -679,7 +679,7 @@ int main(int argc, char* argv[])
   }
 
   check_norm = libxsmm_matdiff_epsilon(&diff);
-  if (0.02 < check_norm) {
+  if (0.01 < check_norm) {
     fprintf(stderr, "FAILED with an error of %f!\n", check_norm);
     exit(EXIT_FAILURE);
   }

--- a/samples/eltwise/eltwise_unary_simple.c
+++ b/samples/eltwise/eltwise_unary_simple.c
@@ -561,33 +561,10 @@ int test_unary_op( const libxsmm_blasint M, const libxsmm_blasint N, const libxs
 
   /* populate error bounds */
   if ( op == RCP_OP || op == RCP_SQRT_OP ) {
-    const int archid = libxsmm_get_target_archid();
-    if  ((dtype_in == LIBXSMM_DATATYPE_F64 && dtype_out == LIBXSMM_DATATYPE_F64)
-      || (dtype_in == LIBXSMM_DATATYPE_F32 && dtype_out == LIBXSMM_DATATYPE_F32))
-    {
-      if (archid >= LIBXSMM_AARCH64_V81 && archid < LIBXSMM_AARCH64_SVE128) {
-        error_bound = 50.0; /* TODO: tighten error bound */
-      }
-      else {
-        error_bound = 0.02;
-      }
-    }
-    else if (dtype_in == LIBXSMM_DATATYPE_BF16 || dtype_out == LIBXSMM_DATATYPE_BF16) {
-      if (archid >= LIBXSMM_AARCH64_V81 && archid < LIBXSMM_AARCH64_SVE128) {
-        error_bound = 50.0; /* TODO: tighten error bound */
-      }
-      else if (archid >= LIBXSMM_X86_GENERIC && archid <= LIBXSMM_X86_AVX2) {
-        error_bound = 0.02;
-      }
-      else {
-        error_bound = 0.0027;
-      }
-    }
-    else if (dtype_in == LIBXSMM_DATATYPE_F16 || dtype_out == LIBXSMM_DATATYPE_F16) {
-      error_bound = 1.9;
-    }
-    else {
-      error_bound = 0.02;
+    if ((dtype_in == LIBXSMM_DATATYPE_BF16 || dtype_out == LIBXSMM_DATATYPE_BF16) && (libxsmm_get_target_archid() >= LIBXSMM_X86_GENERIC) && (libxsmm_get_target_archid() <= LIBXSMM_X86_AVX2)) {
+      error_bound = 0.008;
+    } else {
+      error_bound = 0.0027;
     }
   } else if ( op == SQRT_OP || op == EXP_OP || op == TANH_OP || op == TANH_INV_OP ||
               op == SIGMOID_OP || op == SIGMOID_INV_OP || op == GELU_OP || op == GELU_INV_OP ) {
@@ -596,9 +573,9 @@ int test_unary_op( const libxsmm_blasint M, const libxsmm_blasint N, const libxs
     } else if ( dtype_out == LIBXSMM_DATATYPE_BF16 ) {
       error_bound = 0.007;
     } else if ( (dtype_in == LIBXSMM_DATATYPE_F32) && (dtype_out == LIBXSMM_DATATYPE_BF8) )  {
-      error_bound = 0.2;
+      error_bound = 0.1;
     } else if ( (dtype_in == LIBXSMM_DATATYPE_F32) && (dtype_out == LIBXSMM_DATATYPE_HF8) )  {
-      error_bound = 0.2;
+      error_bound = 0.1;
     } else {
       error_bound = 0.007;
     }

--- a/samples/equation/equation_layernorm.c
+++ b/samples/equation/equation_layernorm.c
@@ -593,7 +593,7 @@ void tpp_layernorm_bwd_bf16(long S1, long S2, long S3, libxsmm_bfloat16 *pdout, 
 
 int main( int argc, char* argv[] ) {
   int ret = EXIT_SUCCESS;
-  double error_bound = 0.0003;
+  double error_bound = 0.0002;
   libxsmm_blasint my_eqn0, my_eqn1, my_eqn2, my_eqn3, my_eqn4, my_eqn5;
   libxsmm_matrix_eqn_function func0, func1, func2, func3, func4, func5;
   libxsmm_meltw_unary_flags jit_reduce_flags = LIBXSMM_MELTW_FLAG_UNARY_NONE;


### PR DESCRIPTION
* It can be assumed libxsmm_matdiff_epsilon mostly impacted by normf_rel (old/new error bounds applicable before/after).
* This keeps calculating error based on libxsmm_matdiff_epsilon (rather than normf_rel).
* Any tighter error bounds introduced by #785 are kept (tighter is better).


