### PR TITLE
Xu add cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(libxsmm C CXX)
 
 message(WARNING
-    "CMake is the not preferred to to build libxsmm for the time being. It's only for some target usages and \"make\" is the tool of choice."
+    "CMake is the not preferred tool to build libxsmm for the time being. It's only for some target usages and \"make\" is the tool of choice."
 )
 
 option(XSMM_STATIC      "static build" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-project(${XSMM_PROJ_NAME} VERSION ${CMAKE_PROJECT_VERSION})
+project(libxsmm VERSION ${CMAKE_PROJECT_VERSION})
 
 # Platform
 set(LINUX False)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+project(${XSMM_PROJ_NAME} VERSION ${CMAKE_PROJECT_VERSION})
+
+# Platform
+set(LINUX False)
+set(MACOS False)
+set(WINDOWS False)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(LINUX True)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  set(WINDOWS True)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(MACOS True)
+endif()
+
+# Setup current directory as project root directory.
+set(XSMM_ROOT_DIR ${PROJECT_SOURCE_DIR})
+
+set(CMAKE_INSTALL_MESSAGE NEVER)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# set(CMAKE_VERBOSE_MAKEFILE ON)
+
+file(GLOB XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${XSMM_ROOT_DIR}/include/libxsmm/*.c)
+list(REMOVE_ITEM XSMM_SRCS ${XSMM_ROOT_DIR}/include/libxsmm/libxsmm_generator_gemm_driver.c)
+
+
+
+if(NOT XSMM_SRCS)
+  file(GLOB XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${XSMM_ROOT_DIR}/src/*.c)
+  list(REMOVE_ITEM XSMM_SRCS ${XSMM_ROOT_DIR}/src/libxsmm_generator_gemm_driver.c)
+endif()
+
+set(XSMM_INCLUDE_DIRS ${XSMM_ROOT_DIR}/include)
+
+add_library(xsmm STATIC ${XSMM_SRCS})
+target_include_directories(xsmm PUBLIC ${XSMM_INCLUDE_DIRS})
+target_compile_definitions(xsmm PRIVATE
+  __BLAS=0
+)
+add_definitions(-DLIBXSMM_DEFAULT_CONFIG -U_DEBUG)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(xsmm PUBLIC Threads::Threads)
+target_link_libraries(xsmm PUBLIC ${CMAKE_DL_LIBS})
+
+include(CheckLibraryExists)
+check_library_exists(m sqrt "" XSMM_LIBM)
+if(XSMM_LIBM)
+  target_link_libraries(xsmm PUBLIC m)
+endif()
+check_library_exists(rt sched_yield "" XSMM_LIBRT)
+if(XSMM_LIBRT)
+  target_link_libraries(xsmm PUBLIC rt)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,19 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(libxsmm C CXX)
 
-option(XSMM_STATIC  "static build" ON)
+message(WARNING
+    "CMake is the not preferred to to build libxsmm for the time being. It's only for some target usages and \"make\" is the tool of choice."
+)
+
+option(XSMM_STATIC      "static build" ON)
 
 # display config
 message(STATUS "******** Build Summary ********")
+message(STATUS "General:")
 message(STATUS "  CMake version         : ${CMAKE_VERSION}")
 message(STATUS "  CMake command         : ${CMAKE_COMMAND}")
 message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
+message(STATUS "Options:")
 message(STATUS "  XSMM_STATIC           : ${XSMM_STATIC}")
 
 # Platform
@@ -49,9 +55,11 @@ else()
 endif()
 
 target_include_directories(xsmm PUBLIC ${XSMM_INCLUDE_DIRS})
-target_compile_definitions(xsmm PRIVATE
-  __BLAS=0
-)
+
+# https://github.com/libxsmm/libxsmm/tree/main#link-instructions
+# Please pass BLAS config by "-D__BLAS=0"
+# target_compile_definitions(xsmm PRIVATE __BLAS=0)
+
 add_definitions(-DLIBXSMM_DEFAULT_CONFIG -U_DEBUG)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-project(libxsmm VERSION ${CMAKE_PROJECT_VERSION})
+project(libxsmm C CXX)
 
 # Platform
 set(LINUX False)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(libxsmm C CXX)
 
+option(XSMM_STATIC  "static build" ON)
+
+# display config
+message(STATUS "******** Build Summary ********")
+message(STATUS "  CMake version         : ${CMAKE_VERSION}")
+message(STATUS "  CMake command         : ${CMAKE_COMMAND}")
+message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
+message(STATUS "  XSMM_STATIC           : ${XSMM_STATIC}")
+
 # Platform
 set(LINUX False)
 set(MACOS False)
@@ -33,7 +42,12 @@ endif()
 
 set(XSMM_INCLUDE_DIRS ${XSMM_ROOT_DIR}/include)
 
-add_library(xsmm STATIC ${XSMM_SRCS})
+if(XSMM_STATIC)
+  add_library(xsmm STATIC ${XSMM_SRCS})
+else()
+  add_library(xsmm SHARED ${XSMM_SRCS})
+endif()
+
 target_include_directories(xsmm PUBLIC ${XSMM_INCLUDE_DIRS})
 target_compile_definitions(xsmm PRIVATE
   __BLAS=0


### PR DESCRIPTION
According to this issue https://github.com/libxsmm/libxsmm/issues/826 discussion, I submit a PR to add cmake support for libxsmm.

# Test on Linux:
```cmd
xu@xu-21HW:~/github/xu_libxsmm/libxsmm$ mkdir build_dir
xu@xu-21HW:~/github/xu_libxsmm/libxsmm$ cd build_dir/
xu@xu-21HW:~/github/xu_libxsmm/libxsmm/build_dir$ cmake ..
-- The C compiler identification is GNU 12.3.0
-- The CXX compiler identification is GNU 12.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Looking for sqrt in m
-- Looking for sqrt in m - found
-- Looking for sched_yield in rt
-- Looking for sched_yield in rt - found
-- Configuring done
-- Generating done
-- Build files have been written to: /home/xu/github/xu_libxsmm/libxsmm/build_dir
xu@xu-21HW:~/github/xu_libxsmm/libxsmm/build_dir$ make
[  1%] Building C object CMakeFiles/xsmm.dir/src/generator_aarch64_instructions.c.o
[  2%] Building C object CMakeFiles/xsmm.dir/src/generator_common.c.o
[  3%] Building C object CMakeFiles/xsmm.dir/src/generator_common_aarch64.c.o
[  4%] Building C object CMakeFiles/xsmm.dir/src/generator_common_x86.c.o
[  5%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm.c.o
[  6%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_aarch64.c.o
[  7%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_amx.c.o
[  8%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_amx_microkernel.c.o
[  9%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_avx2_microkernel.c.o
[ 10%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_avx512_microkernel.c.o
[ 11%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_avx_microkernel.c.o
[ 12%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_common.c.o
[ 13%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_common_aarch64.c.o
[ 14%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_noarch.c.o
[ 15%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_sse_avx_avx2_avx512.c.o
[ 16%] Building C object CMakeFiles/xsmm.dir/src/generator_gemm_sse_microkernel.c.o
[ 17%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise.c.o
[ 18%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_aarch64.c.o
[ 19%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_common.c.o
[ 20%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_gather_scatter_aarch64.c.o
[ 21%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_gather_scatter_avx_avx512.c.o
[ 22%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_misc_aarch64.c.o
[ 23%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_misc_avx_avx512.c.o
[ 25%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_reduce_aarch64.c.o
[ 26%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_reduce_avx_avx512.c.o
[ 27%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_sse_avx_avx512.c.o
[ 28%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_aarch64_asimd.c.o
[ 29%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_aarch64_sve.c.o
[ 30%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_avx.c.o
[ 31%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_avx512.c.o
[ 32%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_common.c.o
[ 33%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_common_x86.c.o
[ 34%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_transform_sse.c.o
[ 35%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_unary_binary_aarch64.c.o
[ 36%] Building C object CMakeFiles/xsmm.dir/src/generator_mateltwise_unary_binary_avx_avx512.c.o
[ 37%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation.c.o
[ 38%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation_aarch64.c.o
[ 39%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation_avx_avx512.c.o
[ 40%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation_regblocks_aarch64.c.o
[ 41%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation_regblocks_avx_avx512.c.o
[ 42%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation_scratch_aarch64.c.o
[ 43%] Building C object CMakeFiles/xsmm.dir/src/generator_matequation_scratch_avx_avx512.c.o
[ 44%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_gemm_ac_rm.c.o
[ 45%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_gemm_ac_rm_aarch64.c.o
[ 46%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_gemm_ac_rm_avx_avx2_avx512.c.o
[ 47%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_gemm_bc_rm.c.o
[ 48%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_gemm_bc_rm_aarch64.c.o
[ 50%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_gemm_bc_rm_avx_avx2_avx512.c.o
[ 51%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm.c.o
[ 52%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_bcsc_bsparse.c.o
[ 53%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c.o
[ 54%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c.o
[ 55%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csc_bsparse.c.o
[ 56%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csc_bsparse_aarch64.c.o
[ 57%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csc_bsparse_avx_avx2_avx512.c.o
[ 58%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csc_csparse.c.o
[ 59%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csc_csparse_avx_avx2_avx512.c.o
[ 60%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csr_asparse.c.o
[ 61%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csr_asparse_aarch64.c.o
[ 62%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csr_asparse_avx_avx2_avx512.c.o
[ 63%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csr_bsparse.c.o
[ 64%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csr_bsparse_aarch64.c.o
[ 65%] Building C object CMakeFiles/xsmm.dir/src/generator_packed_spgemm_csr_bsparse_avx_avx2_avx512.c.o
[ 66%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm.c.o
[ 67%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm_csc_asparse.c.o
[ 68%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm_csc_bsparse.c.o
[ 69%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm_csc_reader.c.o
[ 70%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm_csr_asparse.c.o
[ 71%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm_csr_asparse_reg.c.o
[ 72%] Building C object CMakeFiles/xsmm.dir/src/generator_spgemm_csr_reader.c.o
[ 73%] Building C object CMakeFiles/xsmm.dir/src/generator_x86_instructions.c.o
[ 75%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_barrier.c.o
[ 76%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_cpuid_arm.c.o
[ 77%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_cpuid_x86.c.o
[ 78%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_ext.c.o
[ 79%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_ext_gemm.c.o
[ 80%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_ext_xcopy.c.o
[ 81%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_fsspmdm.c.o
[ 82%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_gemm.c.o
[ 83%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_generator.c.o
[ 84%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_hash.c.o
[ 85%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_lpflt_quant.c.o
[ 86%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_main.c.o
[ 87%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_malloc.c.o
[ 88%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_math.c.o
[ 89%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_matrixeqn.c.o
[ 90%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_memory.c.o
[ 91%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_mhd.c.o
[ 92%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_perf.c.o
[ 93%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_rng.c.o
[ 94%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_sync.c.o
[ 95%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_timer.c.o
[ 96%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_trace.c.o
[ 97%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_utils.c.o
[ 98%] Building C object CMakeFiles/xsmm.dir/src/libxsmm_xcopy.c.o
[100%] Linking C static library libxsmm.a
[100%] Built target xsmm
xu@xu-21HW:~/github/xu_libxsmm/libxsmm/build_dir$
```

# Test on Windows:
```cmd

D:\xu_git\xu_libxsmm\libxsmm>mkdir build_dir

D:\xu_git\xu_libxsmm\libxsmm>cd build_dir

D:\xu_git\xu_libxsmm\libxsmm\build_dir>cmake ..
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.22000.0 to target Windows 10.0.22623.
-- The C compiler identification is MSVC 19.37.32825.0
-- The CXX compiler identification is MSVC 19.37.32825.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Looking for sqrt in m
-- Looking for sqrt in m - not found
-- Looking for sched_yield in rt
-- Looking for sched_yield in rt - not found
-- Configuring done (14.1s)
-- Generating done (0.0s)
-- Build files have been written to: D:/xu_git/xu_libxsmm/libxsmm/build_dir

D:\xu_git\xu_libxsmm\libxsmm\build_dir>msbuild libxsmm.sln
适用于 .NET Framework MSBuild 版本 17.7.2+d6990bcfa
生成启动时间为 2023/11/4 21:08:42。

节点 1 上的项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\libxsmm.sln”(默认目标)。
ValidateSolutionConfiguration:
  正在生成解决方案配置“Debug|x64”。
ValidateProjects:
  在解决方案配置“Debug|x64”中未选定生成项目“ALL_BUILD”。
项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\libxsmm.sln”(1)正在节点 1 上生成“D:\xu_git\xu_libxsmm\libxsmm\build_dir\ZERO_CHECK.vcxproj”(2) (默认目标)。
PrepareForBuild:
  正在创建目录“x64\Debug\ZERO_CHECK\”。
  正在创建目录“x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\”。
InitializeBuildStatus:
  正在创建“x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild”，因为已指定“AlwaysCreate”。
  正在对“x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild”执行 Touch 任务。
PreBuildEvent:
  Checking File Globs
  setlocal
  "C:\Program Files\CMake\bin\cmake.exe" -P D:/xu_git/xu_libxsmm/libxsmm/build_dir/CMakeFiles/VerifyGlobs.cmake
  if %errorlevel% neq 0 goto :cmEnd
  :cmEnd
  endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
  :cmErrorLevel
  exit /b %1
  :cmDone
  if %errorlevel% neq 0 goto :VCEnd
  :VCEnd
CustomBuild:
  Checking Build System
FinalizeBuildStatus:
  正在删除文件“x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild”。
  正在对“x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\ZERO_CHECK.lastbuildstate”执行 Touch 任务。
已完成生成项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\ZERO_CHECK.vcxproj”(默认目标)的操作。

项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\libxsmm.sln”(1)正在节点 1 上生成“D:\xu_git\xu_libxsmm\libxsmm\build_dir\xsmm.vcxproj.metaproj”(3) (默认目标)。
项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\xsmm.vcxproj.metaproj”(3)正在节点 1 上生成“D:\xu_git\xu_libxsmm\libxsmm\build_dir\xsmm.vcxproj”(4) (默认目标)。
PrepareForBuild:
  正在创建目录“xsmm.dir\Debug\”。
  正在创建目录“D:\xu_git\xu_libxsmm\libxsmm\build_dir\Debug\”。
  正在创建目录“xsmm.dir\Debug\xsmm.tlog\”。
InitializeBuildStatus:
  正在创建“xsmm.dir\Debug\xsmm.tlog\unsuccessfulbuild”，因为已指定“AlwaysCreate”。
  正在对“xsmm.dir\Debug\xsmm.tlog\unsuccessfulbuild”执行 Touch 任务。
CustomBuild:
  Building Custom Rule D:/xu_git/xu_libxsmm/libxsmm/CMakeLists.txt
ClCompile:
  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.37.32822\bin\HostX64\x64\CL.exe /c /ID:\xu_git\xu_libxsmm\libxsmm\include /Zi /nologo /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D __BLAS=0 /D LIBXSMM_DEFAULT_CONFIG /D
   "CMAKE_INTDIR=\"Debug\"" /U_DEBUG /Gm- /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"xsmm.dir\Debug\\" /Fd"D:\xu_git\xu_libxsmm\libxsmm\build_dir\Debug\xsmm.pdb" /external:W3 /Gd /TC /errorReport:queue D:\xu_git\xu_libxsmm\libxsmm\src\generator_
  aarch64_instructions.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_common.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_common_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_common_x86.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm.c D:\xu_git\xu_libxsmm\libxs
  mm\src\generator_gemm_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_amx.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_amx_microkernel.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_avx2_microkernel.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_
  avx512_microkernel.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_avx_microkernel.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_common.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_common_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_noarch.c D
  :\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_sse_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_gemm_sse_microkernel.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_aarch64.c D:\xu_git\xu
  _libxsmm\libxsmm\src\generator_mateltwise_common.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_gather_scatter_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_gather_scatter_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_m
  isc_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_misc_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_reduce_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_reduce_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\gen
  erator_mateltwise_sse_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_transform_aarch64_asimd.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_transform_aarch64_sve.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_transform_avx.c D:\x
  u_git\xu_libxsmm\libxsmm\src\generator_mateltwise_transform_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_transform_common.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_transform_common_x86.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_matel
  twise_transform_sse.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_unary_binary_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_mateltwise_unary_binary_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_matequation.c D:\xu_git\xu_libxsmm\libxsmm\sr
  c\generator_matequation_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_matequation_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_matequation_regblocks_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_matequation_regblocks_avx_avx512.c D:\xu_git\xu
  _libxsmm\libxsmm\src\generator_matequation_scratch_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_matequation_scratch_avx_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_gemm_ac_rm.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_gemm_ac_rm_aarch6
  4.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_gemm_ac_rm_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_gemm_bc_rm.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_gemm_bc_rm_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_
  gemm_bc_rm_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_bcsc_bsparse.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_bcsc_bsparse_aarch64.c D:\xu_git\xu_libxsmm\libxsm
  m\src\generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csc_bsparse.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csc_bsparse_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_sp
  gemm_csc_bsparse_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csc_csparse.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csc_csparse_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csr_asparse.c D:\
  xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csr_asparse_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csr_asparse_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csr_bsparse.c D:\xu_git\xu_libxsmm\libxsmm\src\
  generator_packed_spgemm_csr_bsparse_aarch64.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_packed_spgemm_csr_bsparse_avx_avx2_avx512.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_spgemm.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_spgemm_csc_asparse.c D:\xu_git\xu_libxs
  mm\libxsmm\src\generator_spgemm_csc_bsparse.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_spgemm_csc_reader.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_spgemm_csr_asparse.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_spgemm_csr_asparse_reg.c D:\xu_git\xu_libxsmm\libxs
  mm\src\generator_spgemm_csr_reader.c D:\xu_git\xu_libxsmm\libxsmm\src\generator_x86_instructions.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_barrier.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_cpuid_arm.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_cpuid_x86.c D:\xu_git\x
  u_libxsmm\libxsmm\src\libxsmm_ext.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_ext_gemm.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_ext_xcopy.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_fsspmdm.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_gemm.c D:\xu_git\xu_libxsmm\libxsm
  m\src\libxsmm_generator.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_hash.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_lpflt_quant.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_main.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_malloc.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm
  _math.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_matrixeqn.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_memory.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_mhd.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_perf.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_rng.c D:\xu_git\xu_l
  ibxsmm\libxsmm\src\libxsmm_sync.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_timer.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_trace.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_utils.c D:\xu_git\xu_libxsmm\libxsmm\src\libxsmm_xcopy.c
  generator_aarch64_instructions.c
  generator_common.c
  generator_common_aarch64.c
  generator_common_x86.c
  generator_gemm.c
  generator_gemm_aarch64.c
  generator_gemm_amx.c
  generator_gemm_amx_microkernel.c
  generator_gemm_avx2_microkernel.c
  generator_gemm_avx512_microkernel.c
  generator_gemm_avx_microkernel.c
  generator_gemm_common.c
  generator_gemm_common_aarch64.c
  generator_gemm_noarch.c
  generator_gemm_sse_avx_avx2_avx512.c
  generator_gemm_sse_microkernel.c
  generator_mateltwise.c
  generator_mateltwise_aarch64.c
  generator_mateltwise_common.c
  generator_mateltwise_gather_scatter_aarch64.c
  Generating Code...
  Compiling...
  generator_mateltwise_gather_scatter_avx_avx512.c
  generator_mateltwise_misc_aarch64.c
  generator_mateltwise_misc_avx_avx512.c
  generator_mateltwise_reduce_aarch64.c
  generator_mateltwise_reduce_avx_avx512.c
  generator_mateltwise_sse_avx_avx512.c
  generator_mateltwise_transform_aarch64_asimd.c
  generator_mateltwise_transform_aarch64_sve.c
  generator_mateltwise_transform_avx.c
  generator_mateltwise_transform_avx512.c
  generator_mateltwise_transform_common.c
  generator_mateltwise_transform_common_x86.c
  generator_mateltwise_transform_sse.c
  generator_mateltwise_unary_binary_aarch64.c
  generator_mateltwise_unary_binary_avx_avx512.c
  generator_matequation.c
  generator_matequation_aarch64.c
  generator_matequation_avx_avx512.c
  generator_matequation_regblocks_aarch64.c
  generator_matequation_regblocks_avx_avx512.c
  Generating Code...
  Compiling...
  generator_matequation_scratch_aarch64.c
  generator_matequation_scratch_avx_avx512.c
  generator_packed_gemm_ac_rm.c
  generator_packed_gemm_ac_rm_aarch64.c
  generator_packed_gemm_ac_rm_avx_avx2_avx512.c
  generator_packed_gemm_bc_rm.c
  generator_packed_gemm_bc_rm_aarch64.c
  generator_packed_gemm_bc_rm_avx_avx2_avx512.c
  generator_packed_spgemm.c
  generator_packed_spgemm_bcsc_bsparse.c
  generator_packed_spgemm_bcsc_bsparse_aarch64.c
  generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
  generator_packed_spgemm_csc_bsparse.c
  generator_packed_spgemm_csc_bsparse_aarch64.c
  generator_packed_spgemm_csc_bsparse_avx_avx2_avx512.c
  generator_packed_spgemm_csc_csparse.c
  generator_packed_spgemm_csc_csparse_avx_avx2_avx512.c
  generator_packed_spgemm_csr_asparse.c
  generator_packed_spgemm_csr_asparse_aarch64.c
  generator_packed_spgemm_csr_asparse_avx_avx2_avx512.c
  Generating Code...
  Compiling...
  generator_packed_spgemm_csr_bsparse.c
  generator_packed_spgemm_csr_bsparse_aarch64.c
  generator_packed_spgemm_csr_bsparse_avx_avx2_avx512.c
  generator_spgemm.c
  generator_spgemm_csc_asparse.c
  generator_spgemm_csc_bsparse.c
  generator_spgemm_csc_reader.c
  generator_spgemm_csr_asparse.c
  generator_spgemm_csr_asparse_reg.c
  generator_spgemm_csr_reader.c
  generator_x86_instructions.c
  libxsmm_barrier.c
  libxsmm_cpuid_arm.c
  libxsmm_cpuid_x86.c
  libxsmm_ext.c
  libxsmm_ext_gemm.c
  libxsmm_ext_xcopy.c
  libxsmm_fsspmdm.c
  libxsmm_gemm.c
  libxsmm_generator.c
  Generating Code...
  Compiling...
  libxsmm_hash.c
  libxsmm_lpflt_quant.c
  libxsmm_main.c
  libxsmm_malloc.c
  libxsmm_math.c
  libxsmm_matrixeqn.c
  libxsmm_memory.c
  libxsmm_mhd.c
  libxsmm_perf.c
  libxsmm_rng.c
  libxsmm_sync.c
  libxsmm_timer.c
  libxsmm_trace.c
  libxsmm_utils.c
  libxsmm_xcopy.c
  Generating Code...
Lib:
  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.37.32822\bin\HostX64\x64\Lib.exe /OUT:"D:\xu_git\xu_libxsmm\libxsmm\build_dir\Debug\xsmm.lib" /NOLOGO /MACHINE:X64  /machine:x64 xsmm.dir\Debug\generator_aarch64_instructions.obj
  xsmm.dir\Debug\generator_common.obj
  xsmm.dir\Debug\generator_common_aarch64.obj
  xsmm.dir\Debug\generator_common_x86.obj
  xsmm.dir\Debug\generator_gemm.obj
  xsmm.dir\Debug\generator_gemm_aarch64.obj
  xsmm.dir\Debug\generator_gemm_amx.obj
  xsmm.dir\Debug\generator_gemm_amx_microkernel.obj
  xsmm.dir\Debug\generator_gemm_avx2_microkernel.obj
  xsmm.dir\Debug\generator_gemm_avx512_microkernel.obj
  xsmm.dir\Debug\generator_gemm_avx_microkernel.obj
  xsmm.dir\Debug\generator_gemm_common.obj
  xsmm.dir\Debug\generator_gemm_common_aarch64.obj
  xsmm.dir\Debug\generator_gemm_noarch.obj
  xsmm.dir\Debug\generator_gemm_sse_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_gemm_sse_microkernel.obj
  xsmm.dir\Debug\generator_mateltwise.obj
  xsmm.dir\Debug\generator_mateltwise_aarch64.obj
  xsmm.dir\Debug\generator_mateltwise_common.obj
  xsmm.dir\Debug\generator_mateltwise_gather_scatter_aarch64.obj
  xsmm.dir\Debug\generator_mateltwise_gather_scatter_avx_avx512.obj
  xsmm.dir\Debug\generator_mateltwise_misc_aarch64.obj
  xsmm.dir\Debug\generator_mateltwise_misc_avx_avx512.obj
  xsmm.dir\Debug\generator_mateltwise_reduce_aarch64.obj
  xsmm.dir\Debug\generator_mateltwise_reduce_avx_avx512.obj
  xsmm.dir\Debug\generator_mateltwise_sse_avx_avx512.obj
  xsmm.dir\Debug\generator_mateltwise_transform_aarch64_asimd.obj
  xsmm.dir\Debug\generator_mateltwise_transform_aarch64_sve.obj
  xsmm.dir\Debug\generator_mateltwise_transform_avx.obj
  xsmm.dir\Debug\generator_mateltwise_transform_avx512.obj
  xsmm.dir\Debug\generator_mateltwise_transform_common.obj
  xsmm.dir\Debug\generator_mateltwise_transform_common_x86.obj
  xsmm.dir\Debug\generator_mateltwise_transform_sse.obj
  xsmm.dir\Debug\generator_mateltwise_unary_binary_aarch64.obj
  xsmm.dir\Debug\generator_mateltwise_unary_binary_avx_avx512.obj
  xsmm.dir\Debug\generator_matequation.obj
  xsmm.dir\Debug\generator_matequation_aarch64.obj
  xsmm.dir\Debug\generator_matequation_avx_avx512.obj
  xsmm.dir\Debug\generator_matequation_regblocks_aarch64.obj
  xsmm.dir\Debug\generator_matequation_regblocks_avx_avx512.obj
  xsmm.dir\Debug\generator_matequation_scratch_aarch64.obj
  xsmm.dir\Debug\generator_matequation_scratch_avx_avx512.obj
  xsmm.dir\Debug\generator_packed_gemm_ac_rm.obj
  xsmm.dir\Debug\generator_packed_gemm_ac_rm_aarch64.obj
  xsmm.dir\Debug\generator_packed_gemm_ac_rm_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_packed_gemm_bc_rm.obj
  xsmm.dir\Debug\generator_packed_gemm_bc_rm_aarch64.obj
  xsmm.dir\Debug\generator_packed_gemm_bc_rm_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_packed_spgemm.obj
  xsmm.dir\Debug\generator_packed_spgemm_bcsc_bsparse.obj
  xsmm.dir\Debug\generator_packed_spgemm_bcsc_bsparse_aarch64.obj
  xsmm.dir\Debug\generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.obj
  xsmm.dir\Debug\generator_packed_spgemm_csc_bsparse.obj
  xsmm.dir\Debug\generator_packed_spgemm_csc_bsparse_aarch64.obj
  xsmm.dir\Debug\generator_packed_spgemm_csc_bsparse_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_packed_spgemm_csc_csparse.obj
  xsmm.dir\Debug\generator_packed_spgemm_csc_csparse_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_packed_spgemm_csr_asparse.obj
  xsmm.dir\Debug\generator_packed_spgemm_csr_asparse_aarch64.obj
  xsmm.dir\Debug\generator_packed_spgemm_csr_asparse_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_packed_spgemm_csr_bsparse.obj
  xsmm.dir\Debug\generator_packed_spgemm_csr_bsparse_aarch64.obj
  xsmm.dir\Debug\generator_packed_spgemm_csr_bsparse_avx_avx2_avx512.obj
  xsmm.dir\Debug\generator_spgemm.obj
  xsmm.dir\Debug\generator_spgemm_csc_asparse.obj
  xsmm.dir\Debug\generator_spgemm_csc_bsparse.obj
  xsmm.dir\Debug\generator_spgemm_csc_reader.obj
  xsmm.dir\Debug\generator_spgemm_csr_asparse.obj
  xsmm.dir\Debug\generator_spgemm_csr_asparse_reg.obj
  xsmm.dir\Debug\generator_spgemm_csr_reader.obj
  xsmm.dir\Debug\generator_x86_instructions.obj
  xsmm.dir\Debug\libxsmm_barrier.obj
  xsmm.dir\Debug\libxsmm_cpuid_arm.obj
  xsmm.dir\Debug\libxsmm_cpuid_x86.obj
  xsmm.dir\Debug\libxsmm_ext.obj
  xsmm.dir\Debug\libxsmm_ext_gemm.obj
  xsmm.dir\Debug\libxsmm_ext_xcopy.obj
  xsmm.dir\Debug\libxsmm_fsspmdm.obj
  xsmm.dir\Debug\libxsmm_gemm.obj
  xsmm.dir\Debug\libxsmm_generator.obj
  xsmm.dir\Debug\libxsmm_hash.obj
  xsmm.dir\Debug\libxsmm_lpflt_quant.obj
  xsmm.dir\Debug\libxsmm_main.obj
  xsmm.dir\Debug\libxsmm_malloc.obj
  xsmm.dir\Debug\libxsmm_math.obj
  xsmm.dir\Debug\libxsmm_matrixeqn.obj
  xsmm.dir\Debug\libxsmm_memory.obj
  xsmm.dir\Debug\libxsmm_mhd.obj
  xsmm.dir\Debug\libxsmm_perf.obj
  xsmm.dir\Debug\libxsmm_rng.obj
  xsmm.dir\Debug\libxsmm_sync.obj
  xsmm.dir\Debug\libxsmm_timer.obj
  xsmm.dir\Debug\libxsmm_trace.obj
  xsmm.dir\Debug\libxsmm_utils.obj
  xsmm.dir\Debug\libxsmm_xcopy.obj
  xsmm.vcxproj -> D:\xu_git\xu_libxsmm\libxsmm\build_dir\Debug\xsmm.lib
FinalizeBuildStatus:
  正在删除文件“xsmm.dir\Debug\xsmm.tlog\unsuccessfulbuild”。
  正在对“xsmm.dir\Debug\xsmm.tlog\xsmm.lastbuildstate”执行 Touch 任务。
已完成生成项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\xsmm.vcxproj”(默认目标)的操作。

已完成生成项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\xsmm.vcxproj.metaproj”(默认目标)的操作。

已完成生成项目“D:\xu_git\xu_libxsmm\libxsmm\build_dir\libxsmm.sln”(默认目标)的操作。


已成功生成。
    0 个警告
    0 个错误

已用时间 00:00:14.53

D:\xu_git\xu_libxsmm\libxsmm\build_dir>
```
## Build in GUI
<img width="943" alt="image" src="https://github.com/libxsmm/libxsmm/assets/8433590/800fef8e-0e1d-49ac-b0e4-cec1fb628ff0">
