### PR TITLE
Fix Const-Cast warnings

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1463,7 +1463,11 @@ else # GCC assumed
     FSTD := -std=$(if $(filter 1,$(FORTRAN)),f2003,f2008)
     CPEDANTIC += -pedantic -Wextra -Wno-variadic-macros \
                  -Wno-unused-parameter -Wwrite-strings \
-                 -Wmissing-field-initializers
+                 -Wmissing-field-initializers -Wwrite-strings \
+                 -Wcast-qual -Wmissing-field-initializers \
+                 -Wimplicit-fallthrough -Wcovered-switch-default \
+                 -Wstring-conversion -Wmisleading-indentation \
+                 -Wctad-maybe-unsupported
     FPEDANTIC += -pedantic -Wextra -Wunused-variable \
                  -Wimplicit-interface -Wimplicit-procedure \
                  -Wconversion -Wintrinsics-std \

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1465,9 +1465,7 @@ else # GCC assumed
                  -Wno-unused-parameter -Wwrite-strings \
                  -Wmissing-field-initializers -Wwrite-strings \
                  -Wcast-qual -Wmissing-field-initializers \
-                 -Wimplicit-fallthrough -Wcovered-switch-default \
-                 -Wstring-conversion -Wmisleading-indentation \
-                 -Wctad-maybe-unsupported
+                 -Wimplicit-fallthrough -Wmisleading-indentation
     FPEDANTIC += -pedantic -Wextra -Wunused-variable \
                  -Wimplicit-interface -Wimplicit-procedure \
                  -Wconversion -Wintrinsics-std \

--- a/scripts/libxsmm_specialized.py
+++ b/scripts/libxsmm_specialized.py
@@ -87,10 +87,13 @@ if __name__ == "__main__":
                     " LIBXSMM_UNUSED(pb);"
                     " LIBXSMM_UNUSED(pc);"
                 )
+            print("#pragma GCC diagnostic push")
+            print("#pragma GCC diagnostic ignored \"-Wcast-qual\"")
             print(
                 "  LIBXSMM_INLINE_XGEMM(float, float, &transa, &transb,"
                 " &m, &n, &k, &alpha, a, &m, b, &k, &beta, c, &m);"
             )
+            print("#pragma GCC diagnostic pop")
             print("#endif")
             print("}")
             print
@@ -176,10 +179,13 @@ if __name__ == "__main__":
                     " LIBXSMM_UNUSED(pb);"
                     " LIBXSMM_UNUSED(pc);"
                 )
+            print("#pragma GCC diagnostic push")
+            print("#pragma GCC diagnostic ignored \"-Wcast-qual\"")
             print(
                 "  LIBXSMM_INLINE_XGEMM(double, double, &transa, &transb,"
                 " &m, &n, &k, &alpha, a, &m, b, &k, &beta, c, &m);"
             )
+            print("#pragma GCC diagnostic pop")
             print("#endif")
             print("}")
             print

--- a/src/generator_gemm_aarch64.c
+++ b/src/generator_gemm_aarch64.c
@@ -1307,13 +1307,14 @@ void libxsmm_generator_gemm_aarch64_kernel( libxsmm_generated_code*        io_ge
       l_new_xgemm_desc_opa = *i_xgemm_desc;
       l_new_xgemm_desc_opa.lda = lda_transpose;
       l_new_xgemm_desc_opa.flags = (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A));
-      l_xgemm_desc_opa = (libxsmm_gemm_descriptor *) &l_new_xgemm_desc_opa;
+      l_xgemm_desc_opa = (libxsmm_gemm_descriptor*) &l_new_xgemm_desc_opa;
     } else {
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
       return;
     }
   } else {
-    l_xgemm_desc_opa = (libxsmm_gemm_descriptor*) i_xgemm_desc;
+    l_new_xgemm_desc_opa = *i_xgemm_desc;
+    l_xgemm_desc_opa = (libxsmm_gemm_descriptor*) &l_new_xgemm_desc_opa;
   }
 
   /* implementing load from struct */

--- a/src/generator_mateltwise_transform_common.c
+++ b/src/generator_mateltwise_transform_common.c
@@ -34,13 +34,14 @@ void libxsmm_generator_transform_x86_microkernel( libxsmm_generated_code*       
     libxsmm_generator_transform_avx512_microkernel( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, i_micro_kernel_config, i_mateltwise_desc );
   } else if ( (io_generated_code->arch >= LIBXSMM_X86_AVX512_VL256_SKX) && (io_generated_code->arch < LIBXSMM_X86_AVX512_SKX) ) {
     /* we need to re-run some setting for KNx */
-    /* TODO: find a better solution for KNx, const to non-const cast is considered harmful.... */
+    /* TODO: find a better solution for KNx */
     const unsigned int l_save_arch = io_generated_code->arch;
+    libxsmm_mateltwise_kernel_config l_new_micro_kernel_config = *i_micro_kernel_config;
+    libxsmm_meltw_descriptor l_new_mateltwise_desc = *i_mateltwise_desc;
     io_generated_code->arch = LIBXSMM_X86_AVX2;
-    libxsmm_generator_mateltwise_update_micro_kernel_config_dtype_aluinstr( io_generated_code, (libxsmm_mateltwise_kernel_config*)i_micro_kernel_config, (libxsmm_meltw_descriptor*)i_mateltwise_desc);
-    libxsmm_generator_transform_avx_microkernel( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, i_micro_kernel_config, i_mateltwise_desc );
+    libxsmm_generator_mateltwise_update_micro_kernel_config_dtype_aluinstr( io_generated_code, &l_new_micro_kernel_config, &l_new_mateltwise_desc);
+    libxsmm_generator_transform_avx_microkernel( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_new_micro_kernel_config, &l_new_mateltwise_desc );
     io_generated_code->arch = l_save_arch;
-    libxsmm_generator_mateltwise_update_micro_kernel_config_dtype_aluinstr( io_generated_code, (libxsmm_mateltwise_kernel_config*)i_micro_kernel_config, (libxsmm_meltw_descriptor*)i_mateltwise_desc);
   } else if ( io_generated_code->arch >= LIBXSMM_X86_AVX ) {
     libxsmm_generator_transform_avx_microkernel( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, i_micro_kernel_config, i_mateltwise_desc );
   } else if ( (io_generated_code->arch >= LIBXSMM_X86_GENERIC) /*&& (io_generated_code->arch < LIBXSMM_X86_AVX)*/) {

--- a/src/generator_spgemm_csr_asparse_reg.c
+++ b/src/generator_spgemm_csr_asparse_reg.c
@@ -307,7 +307,7 @@ void libxsmm_generator_spgemm_csr_asparse_reg_x86( libxsmm_generated_code*      
   unsigned int *const l_unique_pos = (unsigned int*)(0 != l_n_row_idx ? malloc(sizeof(unsigned int) * l_n_row_idx) : NULL);
   int *const l_unique_sgn = (int*)(0 != l_n_row_idx ? malloc(sizeof(int) * l_n_row_idx) : NULL);
 
-  const unsigned int l_perm_consts[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  unsigned int l_perm_consts[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
   unsigned int l_need_bcast_reg = 0;
   unsigned int l_bcast_reg_vals[31], l_base_bcast_reg = ~0U, l_nbcast_regs = 0, l_cur_bcast_reg = 0;

--- a/src/generator_x86_instructions.c
+++ b/src/generator_x86_instructions.c
@@ -33,7 +33,7 @@ int internal_x86_instructions_add_offset(const unsigned int i_place1,
     return (1);
   }
   else {
-    unsigned char *l_cptr = (unsigned char *)&i_offset;
+    const unsigned char *l_cptr = (const unsigned char *)&i_offset;
     buf[i_place1] += 0x80;
     buf[i_place2] = l_cptr[0];
     buf[i_place2 + 1] = l_cptr[1];
@@ -4208,7 +4208,7 @@ void libxsmm_x86_instruction_full_vec_load_of_constants ( libxsmm_generated_code
   if ( io_generated_code->code_type > 1 )
   {
     unsigned char *buf = (unsigned char *) io_generated_code->generated_code;
-    unsigned char *cval = (unsigned char *) &i_data[0];
+    const unsigned char *cval = (const unsigned char *) &i_data[0];
     int i = io_generated_code->code_size;
     unsigned int l_maxsize = io_generated_code->buffer_size;
     int j = 0;
@@ -4316,7 +4316,7 @@ void libxsmm_x86_instruction_full_vec_load_of_constants ( libxsmm_generated_code
 
     io_generated_code->code_size = i;
   } else {
-    unsigned char *cval = (unsigned char *) &i_data[0];
+    const unsigned char *cval = (const unsigned char *) &i_data[0];
     int j = 0;
     char l_new_code[512];
     int l_max_code_length = 511;
@@ -4329,8 +4329,7 @@ void libxsmm_x86_instruction_full_vec_load_of_constants ( libxsmm_generated_code
       libxsmm_append_code_as_string( io_generated_code, l_new_code, l_code_length );
       for ( j = 0; j < number_of_bytes_to_load; j += 4 ) {
         l_code_length = LIBXSMM_SNPRINTF(l_new_code, l_max_code_length, "                       \".byte 0x%02x, 0x%02x, 0x%02x, 0x%02x\\n\\t\"\n",
-                                                                                                        cval[0],cval[1],cval[2],cval[3] );
-        cval = cval + 4;
+                                                                                                        cval[j+0],cval[j+1],cval[j+2],cval[j+3] );
         libxsmm_append_code_as_string( io_generated_code, l_new_code, l_code_length );
       }
       l_code_length = LIBXSMM_SNPRINTF(l_new_code, l_max_code_length, "                       \".continued_%s:\\n\\t\"\n", i_id );
@@ -4345,8 +4344,7 @@ void libxsmm_x86_instruction_full_vec_load_of_constants ( libxsmm_generated_code
       libxsmm_append_code_as_string( io_generated_code, l_new_code, l_code_length );
       for ( j = 0; j < number_of_bytes_to_load; j += 4 ) {
         l_code_length = LIBXSMM_SNPRINTF(l_new_code, l_max_code_length, "                       .byte 0x%02x, 0x%02x, 0x%02x, 0x%02x\n",
-                                                                                                      cval[0],cval[1],cval[2],cval[3] );
-        cval = cval + 4;
+                                                                                                      cval[j+0],cval[j+1],cval[j+2],cval[j+3] );
         libxsmm_append_code_as_string( io_generated_code, l_new_code, l_code_length );
       }
       l_code_length = LIBXSMM_SNPRINTF(l_new_code, l_max_code_length, "                       .continued_%s:\n", i_id );

--- a/src/libxsmm_barrier.c
+++ b/src/libxsmm_barrier.c
@@ -67,6 +67,8 @@ LIBXSMM_API libxsmm_barrier* libxsmm_barrier_create(int ncores, int nthreads_per
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API void libxsmm_barrier_init(libxsmm_barrier* barrier, int tid)
 {
 #if (0 == LIBXSMM_SYNC)
@@ -256,3 +258,4 @@ LIBXSMM_API void libxsmm_barrier_destroy(const libxsmm_barrier* barrier)
 #endif
   free((libxsmm_barrier*)barrier);
 }
+#pragma GCC diagnostic pop

--- a/src/libxsmm_ext.c
+++ b/src/libxsmm_ext.c
@@ -145,6 +145,8 @@ void LIBXSMM_FSYMBOL(sgemm_batch)(const char transa_array[], const char transb_a
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
 void LIBXSMM_FSYMBOL(dgemm)(const char* transa, const char* transb,
   const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
@@ -181,7 +183,7 @@ void LIBXSMM_FSYMBOL(sgemm)(const char* transa, const char* transb,
     libxsmm_blas_error("sgemm")(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
   }
 }
-
+#pragma GCC diagnostic pop
 
 LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_WEAK
 void LIBXSMM_FSYMBOL(dgemv)(const char* trans, const libxsmm_blasint* m, const libxsmm_blasint* n,
@@ -322,6 +324,8 @@ void LIBXSMM_FSYMBOL(sgemm_batch)(const char transa_array[], const char transb_a
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_NO_TRACE /*LIBXSMM_ATTRIBUTE_WEAK*/
 void LIBXSMM_FSYMBOL(dgemm)(const char* transa, const char* transb,
   const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
@@ -344,6 +348,7 @@ void LIBXSMM_FSYMBOL(sgemm)(const char* transa, const char* transb,
   LIBXSMM_INLINE_XGEMM(float, float, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
   internal_noblas_error("sgemm")(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_BLAS_SYMBOL_VISIBILITY LIBXSMM_ATTRIBUTE_NO_TRACE /*LIBXSMM_ATTRIBUTE_WEAK*/

--- a/src/libxsmm_ext_gemm.c
+++ b/src/libxsmm_ext_gemm.c
@@ -285,6 +285,8 @@ LIBXSMM_APIEXT LIBXSMM_ATTRIBUTE_USED void LIBXSMM_FSYMBOL(__wrap_sgemm)(
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_APIEXT LIBXSMM_ATTRIBUTE_USED void LIBXSMM_FSYMBOL(__wrap_dgemv)(const char* trans, const libxsmm_blasint* m, const libxsmm_blasint* n,
   const double* alpha, const double* a, const libxsmm_blasint* lda, const double* x, const libxsmm_blasint* incx,
   const double* beta, double* y, const libxsmm_blasint* incy)
@@ -347,6 +349,7 @@ LIBXSMM_APIEXT LIBXSMM_ATTRIBUTE_USED void LIBXSMM_FSYMBOL(__wrap_sgemv)(const c
     LIBXSMM_GEMV_SYMBOL(float)(trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
   }
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_APIEXT LIBXSMM_ATTRIBUTE_USED void __wrap_dgemm_batch_strided(
@@ -399,6 +402,8 @@ LIBXSMM_APIEXT LIBXSMM_ATTRIBUTE_USED void __wrap_sgemm_batch(
 #endif /*defined(LIBXSMM_BUILD) && defined(LIBXSMM_BUILD_EXT)*/
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API_INLINE void internal_gemm_batch_omp(libxsmm_datatype iprec, libxsmm_datatype oprec,
   const char* transa, const char* transb, const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
   const void* alpha, const void* a, const libxsmm_blasint* lda, const libxsmm_blasint* stride_a,
@@ -597,7 +602,7 @@ LIBXSMM_API_INLINE void internal_gemm_batch_omp(libxsmm_datatype iprec, libxsmm_
   }
 #endif
 }
-
+#pragma GCC diagnostic pop
 
 LIBXSMM_APIEXT void libxsmm_gemm_batch_omp(libxsmm_datatype iprec, libxsmm_datatype oprec,
   const char* transa, const char* transb, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,

--- a/src/libxsmm_ext_xcopy.c
+++ b/src/libxsmm_ext_xcopy.c
@@ -334,7 +334,10 @@ LIBXSMM_APIEXT void libxsmm_otrans_omp(void* out, const void* in, unsigned int t
               } break;
             }
             if (NULL != kernel.ptr) { /* JIT-kernel available */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
               LIBXSMM_TCOPY_CALL(kernel, typesize, in, ldi, out, ldo);
+#pragma GCC diagnostic pop
               return; /* fast path */
             }
           }

--- a/src/libxsmm_fsspmdm.c
+++ b/src/libxsmm_fsspmdm.c
@@ -488,6 +488,8 @@ LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API void libxsmm_fsspmdm_execute(const libxsmm_fsspmdm* handle, const void* B, void* C)
 {
   libxsmm_gemm_param gemm_param;
@@ -512,6 +514,7 @@ LIBXSMM_API void libxsmm_fsspmdm_execute(const libxsmm_fsspmdm* handle, const vo
     }
   }
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API void libxsmm_dfsspmdm_execute(const libxsmm_dfsspmdm* handle, const double* B, double* C)

--- a/src/libxsmm_gemm.c
+++ b/src/libxsmm_gemm.c
@@ -534,6 +534,8 @@ LIBXSMM_API void libxsmm_gemm_groups(
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API void libxsmm_dgemm(const char* transa, const char* transb,
   const libxsmm_blasint* m, const libxsmm_blasint* n, const libxsmm_blasint* k,
   const double* alpha, const double* a, const libxsmm_blasint* lda,
@@ -923,6 +925,7 @@ LIBXSMM_API int libxsmm_gemm_batch_kernel(libxsmm_gemmfunction kernel, libxsmm_b
   /* coverity[missing_unlock] */
   return result;
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API libxsmm_bitfield libxsmm_gemm_batch_flags(
@@ -956,6 +959,8 @@ LIBXSMM_API libxsmm_bitfield libxsmm_gemm_batch_flags(
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API void libxsmm_gemm_batch_blas(libxsmm_datatype iprec, libxsmm_datatype oprec,
   const char* transa, const char* transb, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
   const void* alpha, const void* a, const libxsmm_blasint* lda, const libxsmm_blasint stride_a[],
@@ -1126,6 +1131,7 @@ LIBXSMM_API void libxsmm_gemm_batch_task(libxsmm_datatype iprec, libxsmm_datatyp
   }
 #endif
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API void libxsmm_gemm_batch(libxsmm_datatype iprec, libxsmm_datatype oprec,

--- a/src/libxsmm_main.c
+++ b/src/libxsmm_main.c
@@ -1511,7 +1511,7 @@ LIBXSMM_API_DTOR void libxsmm_finalize(void)
 #endif
               libxsmm_xfree(code.ptr_const, 0/*no check*/);
               /* round-up size (it is fine to assume 4 KB pages since it is likely more accurate than not rounding up) */
-              internal_registry_nbytes += LIBXSMM_UP2(size + (((char*)code.ptr_const) - (char*)buffer), LIBXSMM_PAGE_MINSIZE);
+              internal_registry_nbytes += LIBXSMM_UP2(size + (((const char*)code.ptr_const) - (char*)buffer), LIBXSMM_PAGE_MINSIZE);
             }
             else ++internal_registry_nleaks;
           }
@@ -2970,7 +2970,7 @@ LIBXSMM_API int libxsmm_get_registry_info(libxsmm_registry_info* info)
 #endif
           result = libxsmm_get_malloc_xinfo(code.ptr_const, &buffer_size, NULL/*flags*/, &buffer);
           if (EXIT_SUCCESS == result) {
-            info->nbytes += LIBXSMM_UP2(buffer_size + (((char*)code.ptr_const) - (char*)buffer), LIBXSMM_PAGE_MINSIZE);
+            info->nbytes += LIBXSMM_UP2(buffer_size + (((const char*)code.ptr_const) - (char*)buffer), LIBXSMM_PAGE_MINSIZE);
           }
         }
         else {

--- a/src/libxsmm_malloc.c
+++ b/src/libxsmm_malloc.c
@@ -600,7 +600,10 @@ LIBXSMM_API_INTERN void internal_scratch_free(const void* memory, internal_mallo
   const size_t counter = LIBXSMM_ATOMIC_SUB_FETCH(&pool->instance.counter, 1, LIBXSMM_ATOMIC_SEQ_CST);
   char *const pool_buffer = pool->instance.buffer;
 # if (!defined(NDEBUG) || defined(LIBXSMM_MALLOC_SCRATCH_TRIM_HEAD))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
   char *const buffer = (char*)memory; /* non-const */
+#pragma GCC diagnostic pop
   LIBXSMM_ASSERT(pool_buffer <= buffer && buffer < pool_buffer + pool->instance.minsize);
 # endif
   LIBXSMM_ASSERT(pool_buffer <= pool->instance.head);

--- a/src/libxsmm_malloc.c
+++ b/src/libxsmm_malloc.c
@@ -445,6 +445,8 @@ LIBXSMM_API_INTERN size_t libxsmm_alignment(size_t size, size_t alignment)
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API_INLINE
 LIBXSMM_ATTRIBUTE_NO_SANITIZE(address)
 internal_malloc_info_type* internal_malloc_info(const void* memory, int check)
@@ -511,6 +513,7 @@ internal_malloc_info_type* internal_malloc_info(const void* memory, int check)
   }
   return result;
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API_INLINE size_t internal_get_scratch_size(const internal_malloc_pool_type* exclude)

--- a/src/libxsmm_memory.c
+++ b/src/libxsmm_memory.c
@@ -535,7 +535,7 @@ LIBXSMM_API unsigned long long libxsmm_hash_string(const char string[])
   }
   else { /* reinterpret directly as hash value */
     LIBXSMM_ASSERT(NULL != string);
-    result = *(unsigned long long*)string;
+    result = *(const unsigned long long*)string;
   }
   return result;
 }

--- a/src/libxsmm_mhd.c
+++ b/src/libxsmm_mhd.c
@@ -534,6 +534,8 @@ LIBXSMM_API int libxsmm_mhd_element_comparison(
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 /* coverity[var_deref_op] */
 LIBXSMM_API_INLINE int internal_mhd_minmax(const void* data, size_t nelements,
   libxsmm_mhd_elemtype type, const void* minval, const void* maxval)
@@ -576,6 +578,7 @@ LIBXSMM_API_INLINE int internal_mhd_minmax(const void* data, size_t nelements,
   }
   return result;
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API_INTERN int internal_mhd_read(FILE* /*file*/, void* /*data*/, const size_t /*size*/[], const size_t /*pitch*/[],
@@ -828,7 +831,7 @@ LIBXSMM_API_INTERN int internal_mhd_write(FILE* file, const void* data, const si
                 result = libxsmm_mhd_element_conversion(element, type, type_data, data, minval, maxval);
                 if (EXIT_SUCCESS == result) {
                   if (1 == fwrite(element, typesize, 1, file)) {
-                    data = ((char*)data) + typesize_data;
+                    data = ((const char*)data) + typesize_data;
                   }
                   else {
                     result = EXIT_FAILURE;

--- a/src/libxsmm_trace.c
+++ b/src/libxsmm_trace.c
@@ -226,7 +226,6 @@ unsigned int libxsmm_backtrace(const void* buffer[], unsigned int size, unsigned
   }
   return result;
 }
-#pragma GCC diagnostic pop
 
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
@@ -260,6 +259,7 @@ LIBXSMM_API_INLINE const char* internal_trace_get_symbolname(const void* address
   return result;
 }
 #endif
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API LIBXSMM_ATTRIBUTE_NO_TRACE

--- a/src/libxsmm_trace.c
+++ b/src/libxsmm_trace.c
@@ -191,6 +191,8 @@ LIBXSMM_API int libxsmm_trace_finalize(void)
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API LIBXSMM_ATTRIBUTE_NO_TRACE unsigned int libxsmm_backtrace(const void* /*buffer*/[], unsigned int /*size*/, unsigned int /*skip*/);
 LIBXSMM_API
 #if defined(_WIN32)
@@ -224,6 +226,7 @@ unsigned int libxsmm_backtrace(const void* buffer[], unsigned int size, unsigned
   }
   return result;
 }
+#pragma GCC diagnostic pop
 
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)

--- a/src/libxsmm_xcopy.c
+++ b/src/libxsmm_xcopy.c
@@ -190,6 +190,8 @@ LIBXSMM_API void libxsmm_otrans_task_internal(void* out, const void* in, unsigne
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 LIBXSMM_API_INTERN void libxsmm_matcopy_internal(void* out, const void* in,
   unsigned int typesize, unsigned int ldi, unsigned int ldo,
   unsigned int m0, unsigned int m1, unsigned int n0, unsigned int n1,
@@ -616,6 +618,7 @@ LIBXSMM_API void libxsmm_itrans_internal(char* inout, void* scratch, unsigned in
     }
   }
 }
+#pragma GCC diagnostic pop
 
 
 LIBXSMM_API void libxsmm_itrans(void* inout, unsigned int typesize,

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_const_cast_warnings-1.17-3689
+fix_const_cast_warnings-1.17-3690

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_const_cast_warnings-1.17-3688
+fix_const_cast_warnings-1.17-3689

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-main-1.17-3686
+fix_const_cast_warnings-1.17-3687

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_const_cast_warnings-1.17-3687
+fix_const_cast_warnings-1.17-3688


### PR DESCRIPTION
fixing warnings when compiling LIBXSMM with -Wcast-qual:
    - fixed dropping of const qual where it could be avoided without perf
      loss
    - selectively disabling the warning when calling into JIT'ed ASM code