### PR TITLE
Implement correct Intel AMX ABI such that libxsmm can savely interoperate with other SW using Intel AMX

### DIFF
--- a/samples/spmm/.gitignore
+++ b/samples/spmm/.gitignore
@@ -1,0 +1,3 @@
+spmm_kernel
+kernel_test/.generate_spmm_test_scripts
+kernel_test/*.slurm

--- a/samples/xgemm/.gitignore
+++ b/samples/xgemm/.gitignore
@@ -3,4 +3,5 @@ gemm_kernel
 gemm_kernel_fused
 gemm_kernel_parallel
 kernel_test/.generate_gemm_test_scripts
+kernel_test/.generate_spmm_test_scripts
 kernel_test/*.slurm

--- a/src/generator_gemm_amx.c
+++ b/src/generator_gemm_amx.c
@@ -1916,7 +1916,6 @@ void libxsmm_generator_gemm_amx_kernel_wrapper( libxsmm_generated_code* io_gener
     }
     l_gp_reg_mapping.gp_reg_reduce_loop = LIBXSMM_X86_GP_REG_R10;
   }
-#endif
   l_gp_reg_mapping.gp_reg_decompressed_a = LIBXSMM_X86_GP_REG_RCX;
   l_gp_reg_mapping.gp_reg_bitmap_a = LIBXSMM_X86_GP_REG_RBX;
   l_gp_reg_mapping.gp_reg_mloop = LIBXSMM_X86_GP_REG_R12;

--- a/src/generator_gemm_amx.c
+++ b/src/generator_gemm_amx.c
@@ -1853,9 +1853,11 @@ void libxsmm_generator_gemm_amx_kernel_wrapper( libxsmm_generated_code* io_gener
   /* define gp register mapping */
   libxsmm_reset_x86_gp_reg_mapping( &l_gp_reg_mapping );
 #if defined(_WIN32) || defined(__CYGWIN__)
-#else
+  l_gp_reg_mapping.gp_reg_param_struct = LIBXSMM_X86_GP_REG_RCX;
+#else /* match calling convention on Linux */
   l_gp_reg_mapping.gp_reg_param_struct = LIBXSMM_X86_GP_REG_RDI;
-  l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RDI;
+#endif
+  l_gp_reg_mapping.gp_reg_a = l_gp_reg_mapping.gp_reg_param_struct;
   l_gp_reg_mapping.gp_reg_b = LIBXSMM_X86_GP_REG_RSI;
   l_gp_reg_mapping.gp_reg_c = LIBXSMM_X86_GP_REG_RDX;
   l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_RCX;

--- a/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
@@ -397,6 +397,17 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
   /* open asm */
   libxsmm_x86_instruction_open_stream_gemm( io_generated_code, &l_gp_reg_mapping, 0, i_xgemm_desc->prefetch );
 
+  /* saving current tileconfig to the stack */
+  if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ) {
+    libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_SUBQ, LIBXSMM_X86_GP_REG_RSP, 64 );
+    libxsmm_x86_instruction_tile_control( io_generated_code, 1000, io_generated_code->arch, LIBXSMM_X86_INSTR_STTILECFG, LIBXSMM_X86_GP_REG_RSP, 0, NULL );
+  /* we only set the config in this kernel */
+  } else if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ) {
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, l_gp_reg_mapping.gp_reg_param_struct, LIBXSMM_X86_GP_REG_RSI );
+    libxsmm_x86_instruction_alu_mem( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, LIBXSMM_X86_GP_REG_RSI, LIBXSMM_X86_GP_REG_UNDEF, 0, 24, LIBXSMM_X86_GP_REG_RDX, 0 );
+    libxsmm_x86_instruction_tile_control( io_generated_code, 1000, io_generated_code->arch, LIBXSMM_X86_INSTR_STTILECFG, LIBXSMM_X86_GP_REG_RDX, 0, NULL );
+  }
+
   /* implementing load from struct */
   if (l_emit_compute > 0) {
     if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ) {
@@ -744,12 +755,6 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
   }
 
   if (l_is_amx_kernel > 0) {
-    /* Conditionally perform a tilerelease */
-    if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0)) ||
-         (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0))) {
-      libxsmm_x86_instruction_tile_control( io_generated_code, 0, io_generated_code->arch,
-          LIBXSMM_X86_INSTR_TILERELEASE, LIBXSMM_X86_GP_REG_UNDEF, 0, NULL );
-    }
     /* free stack */
     if (l_emit_compute > 0){
       if (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GEMM_GETENUM_C_PREC( i_xgemm_desc->datatype )) {
@@ -759,6 +764,15 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
       } else {
 
       }
+    }
+    /* restoring current tileconfig to the stack */
+    if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ) {
+      libxsmm_x86_instruction_tile_control( io_generated_code, 1001, io_generated_code->arch, LIBXSMM_X86_INSTR_LDTILECFG, LIBXSMM_X86_GP_REG_RSP, 0, NULL );
+      libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_ADDQ, LIBXSMM_X86_GP_REG_RSP, 64 );
+    } else if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0)) ) {
+      libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, l_gp_reg_mapping.gp_reg_param_struct, LIBXSMM_X86_GP_REG_RSI );
+      libxsmm_x86_instruction_alu_mem( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, LIBXSMM_X86_GP_REG_RSI, LIBXSMM_X86_GP_REG_UNDEF, 0, 24, LIBXSMM_X86_GP_REG_RDX, 0 );
+      libxsmm_x86_instruction_tile_control( io_generated_code, 1001, io_generated_code->arch, LIBXSMM_X86_INSTR_LDTILECFG, LIBXSMM_X86_GP_REG_RDX, 0, NULL );
     }
   }
 

--- a/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
@@ -358,23 +358,16 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
 
   /* define gp register mapping */
   libxsmm_reset_x86_gp_reg_mapping( &l_gp_reg_mapping );
-  /* matching calling convention on Linux */
 #if defined(_WIN32) || defined(__CYGWIN__)
   l_gp_reg_mapping.gp_reg_param_struct = LIBXSMM_X86_GP_REG_RCX;
-  l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RCX;
-  l_gp_reg_mapping.gp_reg_b = LIBXSMM_X86_GP_REG_RDX;
-  l_gp_reg_mapping.gp_reg_c = LIBXSMM_X86_GP_REG_R8;
-  /* TODO: full support for Windows calling convention */
-  l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_UNDEF;
-  l_gp_reg_mapping.gp_reg_b_prefetch = LIBXSMM_X86_GP_REG_UNDEF;
 #else /* match calling convention on Linux */
   l_gp_reg_mapping.gp_reg_param_struct = LIBXSMM_X86_GP_REG_RDI;
-  l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RDI;
+#endif
+  l_gp_reg_mapping.gp_reg_a = l_gp_reg_mapping.gp_reg_param_struct;
   l_gp_reg_mapping.gp_reg_b = LIBXSMM_X86_GP_REG_RSI;
   l_gp_reg_mapping.gp_reg_c = LIBXSMM_X86_GP_REG_RDX;
   l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_RCX;
   l_gp_reg_mapping.gp_reg_b_prefetch = LIBXSMM_X86_GP_REG_R8;
-#endif
   l_gp_reg_mapping.gp_reg_mloop = LIBXSMM_X86_GP_REG_R12;
   l_gp_reg_mapping.gp_reg_nloop = LIBXSMM_X86_GP_REG_R13;
   l_gp_reg_mapping.gp_reg_kloop = LIBXSMM_X86_GP_REG_R14;

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_avx512_gemm_with_A_decompress_BCSC_AT_CT_enabled-1.17-3725
+feature_amx_abi-1.17-3701

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_amx_abi-1.17-3701
+feature_amx_abi-1.17-3702

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_amx_abi-1.17-3702
+feature_amx_abi-1.17-3703


### PR DESCRIPTION
@egeor : 
- please comment primary on the usage of op.quaternary, if felt this API is OK, It can be seen best in the GEMM driver as now the same gemm_param struct is passed to all 3 kernels (tile config, compute, tile release).
- We could also change to API to two functions: a) tileconfig + new struct and runtime parameter for select to set or to restore b) GEMM kernel without tileconfig.  