### PR TITLE
refined AMX ABI implementation

### DIFF
--- a/samples/spmm/spmm_kernel.c
+++ b/samples/spmm/spmm_kernel.c
@@ -454,7 +454,12 @@ double jit_matmul( const spmm_def*    i_spmm_def,
   gemm_param.c.primary = (void*)o_c;
   /* run external tileconfig */
   if (i_spmm_def->tc_config) {
-    cfg_tr.tilecfg( &l_tilestate );
+    /* this is to trigger the different ABI behavior in the kernel */
+    if ( i_spmm_def->n % 2 == 0 ) {
+      cfg_tr.tilecfg( &l_tilestate );
+    } else {
+      cfg_tr.tilecfg( NULL );
+    }
   }
   l_test_jit.gemm( &gemm_param );
 
@@ -473,7 +478,12 @@ double jit_matmul( const spmm_def*    i_spmm_def,
 
   /* run external tilerelease */
   if (i_spmm_def->tc_config) {
-    rls_tr.tilecfg( &l_tilestate );
+    /* this is to trigger the different ABI behavior in the kernel */
+    if ( i_spmm_def->n % 2 == 0 ) {
+      rls_tr.tilecfg( &l_tilestate );
+    } else {
+      rls_tr.tilecfg( NULL );
+    }
   }
 
   printf("function pointer address: %llx\n", (unsigned long long)l_test_jit.xmm);

--- a/samples/xgemm/gemm_kernel.c
+++ b/samples/xgemm/gemm_kernel.c
@@ -2125,7 +2125,12 @@ double jit_matmul( const gemm_def*    i_gemm_def,
 
   /* run external tileconfig */
   if (i_gemm_def->tc_config) {
-    cfg_tr.tilecfg( &l_tilestate );
+    /* this is to trigger the different ABI behavior in the kernel */
+    if ( i_gemm_def->m % 2 == 0 ) {
+      cfg_tr.tilecfg( &l_tilestate );
+    } else {
+      cfg_tr.tilecfg( NULL );
+    }
   }
 
   /* run correctness */
@@ -2270,7 +2275,12 @@ double jit_matmul( const gemm_def*    i_gemm_def,
 
   /* run external tilerelease */
   if (i_gemm_def->tc_config) {
-    rls_tr.tilecfg( &l_tilestate );
+    /* this is to trigger the different ABI behavior in the kernel */
+    if ( i_gemm_def->m % 2 == 0 ) {
+      rls_tr.tilecfg( &l_tilestate );
+    } else {
+      rls_tr.tilecfg( NULL );
+    }
   }
 
   if ( i_print_jit_info == 0 ) {

--- a/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
@@ -402,7 +402,12 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
       libxsmm_x86_instruction_tile_control( io_generated_code, 1000, io_generated_code->arch, LIBXSMM_X86_INSTR_STTILECFG, LIBXSMM_X86_GP_REG_RSP, 0, NULL );
     /* we only set the config in this kernel */
     } else if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ) {
+      libxsmm_jump_label_tracker l_jump_label_tracker;
+      libxsmm_reset_jump_label_tracker(&l_jump_label_tracker);
+      libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_CMPQ, l_gp_reg_mapping.gp_reg_param_struct, 0 );
+      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JE, 0, &l_jump_label_tracker );
       libxsmm_x86_instruction_tile_control( io_generated_code, 1000, io_generated_code->arch, LIBXSMM_X86_INSTR_STTILECFG, l_gp_reg_mapping.gp_reg_param_struct, 0, NULL );
+      libxsmm_x86_instruction_register_jump_label( io_generated_code, 0, &l_jump_label_tracker );
     }
   }
 
@@ -768,7 +773,15 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
       libxsmm_x86_instruction_tile_control( io_generated_code, 1001, io_generated_code->arch, LIBXSMM_X86_INSTR_LDTILECFG, LIBXSMM_X86_GP_REG_RSP, 0, NULL );
       libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_ADDQ, LIBXSMM_X86_GP_REG_RSP, 64 );
     } else if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0)) ) {
+      libxsmm_jump_label_tracker l_jump_label_tracker;
+      libxsmm_reset_jump_label_tracker(&l_jump_label_tracker);
+      libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_CMPQ, l_gp_reg_mapping.gp_reg_param_struct, 0 );
+      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JE, 0, &l_jump_label_tracker );
       libxsmm_x86_instruction_tile_control( io_generated_code, 1001, io_generated_code->arch, LIBXSMM_X86_INSTR_LDTILECFG, l_gp_reg_mapping.gp_reg_param_struct, 0, NULL );
+      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JMP, 1, &l_jump_label_tracker );
+      libxsmm_x86_instruction_register_jump_label( io_generated_code, 0, &l_jump_label_tracker );
+      libxsmm_x86_instruction_tile_control( io_generated_code, 1002, io_generated_code->arch, LIBXSMM_X86_INSTR_TILERELEASE, LIBXSMM_X86_GP_REG_UNDEF, 0, NULL );
+      libxsmm_x86_instruction_register_jump_label( io_generated_code, 1, &l_jump_label_tracker );
     }
   }
 

--- a/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx.c
@@ -402,12 +402,12 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
       libxsmm_x86_instruction_tile_control( io_generated_code, 1000, io_generated_code->arch, LIBXSMM_X86_INSTR_STTILECFG, LIBXSMM_X86_GP_REG_RSP, 0, NULL );
     /* we only set the config in this kernel */
     } else if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ) {
-      libxsmm_jump_label_tracker l_jump_label_tracker;
-      libxsmm_reset_jump_label_tracker(&l_jump_label_tracker);
+      libxsmm_jump_label_tracker l_jump_label_tracker_tc;
+      libxsmm_reset_jump_label_tracker(&l_jump_label_tracker_tc);
       libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_CMPQ, l_gp_reg_mapping.gp_reg_param_struct, 0 );
-      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JE, 0, &l_jump_label_tracker );
+      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JE, 0, &l_jump_label_tracker_tc );
       libxsmm_x86_instruction_tile_control( io_generated_code, 1000, io_generated_code->arch, LIBXSMM_X86_INSTR_STTILECFG, l_gp_reg_mapping.gp_reg_param_struct, 0, NULL );
-      libxsmm_x86_instruction_register_jump_label( io_generated_code, 0, &l_jump_label_tracker );
+      libxsmm_x86_instruction_register_jump_label( io_generated_code, 0, &l_jump_label_tracker_tc );
     }
   }
 
@@ -773,15 +773,15 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_avx_avx2_avx512_amx( libxsmm_g
       libxsmm_x86_instruction_tile_control( io_generated_code, 1001, io_generated_code->arch, LIBXSMM_X86_INSTR_LDTILECFG, LIBXSMM_X86_GP_REG_RSP, 0, NULL );
       libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_ADDQ, LIBXSMM_X86_GP_REG_RSP, 64 );
     } else if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0)) ) {
-      libxsmm_jump_label_tracker l_jump_label_tracker;
-      libxsmm_reset_jump_label_tracker(&l_jump_label_tracker);
+      libxsmm_jump_label_tracker l_jump_label_tracker_tc;
+      libxsmm_reset_jump_label_tracker(&l_jump_label_tracker_tc);
       libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_CMPQ, l_gp_reg_mapping.gp_reg_param_struct, 0 );
-      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JE, 0, &l_jump_label_tracker );
+      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JE, 0, &l_jump_label_tracker_tc );
       libxsmm_x86_instruction_tile_control( io_generated_code, 1001, io_generated_code->arch, LIBXSMM_X86_INSTR_LDTILECFG, l_gp_reg_mapping.gp_reg_param_struct, 0, NULL );
-      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JMP, 1, &l_jump_label_tracker );
-      libxsmm_x86_instruction_register_jump_label( io_generated_code, 0, &l_jump_label_tracker );
+      libxsmm_x86_instruction_jump_to_label( io_generated_code, LIBXSMM_X86_INSTR_JMP, 1, &l_jump_label_tracker_tc );
+      libxsmm_x86_instruction_register_jump_label( io_generated_code, 0, &l_jump_label_tracker_tc );
       libxsmm_x86_instruction_tile_control( io_generated_code, 1002, io_generated_code->arch, LIBXSMM_X86_INSTR_TILERELEASE, LIBXSMM_X86_GP_REG_UNDEF, 0, NULL );
-      libxsmm_x86_instruction_register_jump_label( io_generated_code, 1, &l_jump_label_tracker );
+      libxsmm_x86_instruction_register_jump_label( io_generated_code, 1, &l_jump_label_tracker_tc );
     }
   }
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_amx_abi_nullptr-1.17-3707
+feature_amx_abi_nullptr-1.17-3708

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_eltw_nts-1.17-3710
+feature_amx_abi_nullptr-1.17-3707


### PR DESCRIPTION
when we provide NULL to external config/restore kernels they don't save/restore the possibly currently configured tilestate


