### PR TITLE
Add variant for reduce rows TPP with limited unrolling (for large values of M)

### DIFF
--- a/src/generator_mateltwise_reduce_avx_avx512.c
+++ b/src/generator_mateltwise_reduce_avx_avx512.c
@@ -1609,7 +1609,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
   }
 
   /* In this case we do not support the algorithm with "on the fly transpose" */
-  if ((i_mateltwise_desc->m >= 1) || io_generated_code->arch < LIBXSMM_X86_AVX512_VL256_SKX || (LIBXSMM_DATATYPE_F64 == libxsmm_meltw_getenum_precision(i_mateltwise_desc, LIBXSMM_MELTW_FIELD_COMP))) {
+  if ((i_mateltwise_desc->m >= 256) || io_generated_code->arch < LIBXSMM_X86_AVX512_VL256_SKX || (LIBXSMM_DATATYPE_F64 == libxsmm_meltw_getenum_precision(i_mateltwise_desc, LIBXSMM_MELTW_FIELD_COMP))) {
     unsigned int reg_sum = 15, reg_sum_squared = 14;
     unsigned int cur_vreg;
     unsigned int mask_out = 13;
@@ -1635,7 +1635,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
         vlen = 8;
       } else {
       }
-    } else if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_VL256_SKX) && (i_mateltwise_desc->m >= 1)) {
+    } else if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_VL256_SKX) && (i_mateltwise_desc->m >= 256)) {
       /* Reconfig if large m and arch >= avx512 */
       cvt_vreg_aux0 = 31; cvt_vreg_aux1 = 30; cvt_vreg_aux2 = 29; cvt_vreg_aux3 = 28;
       cvt_mask_aux0 = 7; cvt_mask_aux1 = 6; cvt_mask_aux2 = 5;

--- a/src/generator_mateltwise_reduce_avx_avx512.c
+++ b/src/generator_mateltwise_reduce_avx_avx512.c
@@ -1851,7 +1851,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
         }
 
         /* If we have remainder, then we want to blend in -INF for the zero'ed out entries */
-        if ((use_m_masking == 1) && (im == (peeled_m_trips-1))) {
+        if ((flag_reduce_op_max > 0 || flag_reduce_op_min > 0) && (use_m_masking == 1) && (im == (peeled_m_trips-1))) {
           unsigned int blend_vreg_mask_id = (arch_has_maskregs_and_prec_f64 > 0 || arch_avx512_and_large_m > 0) ? 0 : (mask_reg) << 4;
           unsigned int blend_mask_id = (arch_has_maskregs_and_prec_f64 > 0 || arch_avx512_and_large_m > 0) ? mask_reg : 0;
           unsigned int blend_instr = (arch_has_maskregs_and_prec_f64 > 0) ? LIBXSMM_X86_INSTR_VPBLENDMQ :

--- a/src/generator_mateltwise_reduce_avx_avx512.c
+++ b/src/generator_mateltwise_reduce_avx_avx512.c
@@ -1631,7 +1631,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
         vlen = 8;
       } else {
       }
-    } else if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_VL256_SKX) && (i_mateltwise_desc->m >= 1)) {
+    } else if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_SKX) && (i_mateltwise_desc->m >= 1)) {
       /* Reconfig if large m and arch >= avx512 */
       cvt_vreg_aux0 = 31; cvt_vreg_aux1 = 30; cvt_vreg_aux2 = 29; cvt_vreg_aux3 = 28;
       cvt_mask_aux0 = 7; cvt_mask_aux1 = 6; cvt_mask_aux2 = 5;
@@ -1675,7 +1675,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
 
     if (arch_avx512_and_large_m > 0) {
       mask_out = 1;
-      libxsmm_generator_initialize_avx512_mask(io_generated_code, LIBXSMM_X86_GP_REG_RAX, mask_out, vlen - 1, (libxsmm_datatype)libxsmm_meltw_getenum_precision( i_mateltwise_desc, LIBXSMM_MELTW_FIELD_OUT ));
+      libxsmm_generator_initialize_avx512_mask(io_generated_code, LIBXSMM_X86_GP_REG_RAX, mask_out, vlen - 1, LIBXSMM_DATATYPE_F32);
     } else if (LIBXSMM_DATATYPE_BF16 == libxsmm_meltw_getenum_precision( i_mateltwise_desc, LIBXSMM_MELTW_FIELD_OUT )) {
       cvt_vreg_aux0 = available_vregs - 1;
       cvt_vreg_aux1 = available_vregs - 2;
@@ -1696,7 +1696,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
     if (use_m_masking == 1) {
       if (arch_has_maskregs_and_prec_f64 > 0 || arch_avx512_and_large_m > 0) {
         mask_reg = 2;
-        libxsmm_generator_initialize_avx512_mask(io_generated_code, LIBXSMM_X86_GP_REG_RAX, mask_reg, vlen - (m % vlen), (libxsmm_datatype)libxsmm_meltw_getenum_precision( i_mateltwise_desc, LIBXSMM_MELTW_FIELD_OUT ));
+        libxsmm_generator_initialize_avx512_mask(io_generated_code, LIBXSMM_X86_GP_REG_RAX, mask_reg, vlen - (m % vlen), (arch_has_maskregs_and_prec_f64 > 0) ? LIBXSMM_DATATYPE_F64 : LIBXSMM_DATATYPE_F32);
         mask_reg_in = mask_reg;
       } else {
         const int datatype = libxsmm_meltw_getenum_precision(i_mateltwise_desc, LIBXSMM_MELTW_FIELD_COMP);

--- a/src/generator_mateltwise_reduce_avx_avx512.c
+++ b/src/generator_mateltwise_reduce_avx_avx512.c
@@ -1631,7 +1631,7 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
         vlen = 8;
       } else {
       }
-    } else if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_SKX) && (i_mateltwise_desc->m >= 1)) {
+    } else if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_VL256_SKX) && (i_mateltwise_desc->m >= 1)) {
       /* Reconfig if large m and arch >= avx512 */
       cvt_vreg_aux0 = 31; cvt_vreg_aux1 = 30; cvt_vreg_aux2 = 29; cvt_vreg_aux3 = 28;
       cvt_mask_aux0 = 7; cvt_mask_aux1 = 6; cvt_mask_aux2 = 5;
@@ -1639,8 +1639,13 @@ void libxsmm_generator_reduce_rows_avx512_microkernel( libxsmm_generated_code*  
       reg_sum_squared = 26;
       available_vregs = 26;
       arch_avx512_and_large_m = 1;
-      vlen = 16;
-      vname_comp = 'z';
+      if (io_generated_code->arch >= LIBXSMM_X86_AVX512_SKX) {
+        vlen = 16;
+        vname_comp = 'z';
+      } else {
+        vlen = 8;
+        vname_comp = 'y';
+      }
     }
 
     m                 = i_mateltwise_desc->m;

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3714
+fix_reduce_code_size-1.17-3715

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3713
+fix_reduce_code_size-1.17-3714

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3718
+fix_reduce_code_size-1.17-3719

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_high_prec_reciprocal-1.17-3711
+fix_reduce_code_size-1.17-3712

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3715
+fix_reduce_code_size-1.17-3716

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3716
+fix_reduce_code_size-1.17-3717

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3712
+fix_reduce_code_size-1.17-3713

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_reduce_code_size-1.17-3717
+fix_reduce_code_size-1.17-3718


### PR DESCRIPTION
This PR adds variant for reduce rows TPP with limited unrolling (for large values of M). In the future we may want to evaluate the perf of this codepath VS the "online transpose" codepath and deprecate the latter if not beneficial.