### PR TITLE
Fix build warning/error for Linux perf support.

### DIFF
--- a/src/libxsmm_perf.c
+++ b/src/libxsmm_perf.c
@@ -13,6 +13,7 @@
 
 #include "perf_jitdump.h"
 #if defined(LIBXSMM_PERF_JITDUMP) && !defined(_WIN32)
+#include "libxsmm_memory.h"
 # include <sys/mman.h>
 # include <sys/types.h>
 # include <sys/types.h>

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_mxfp4_bf16_amx_gemms-1.17-3729
+fix_libxmm_perf_support-16277


### PR DESCRIPTION
Compiler warns:
libxsmm/src/libxsmm_perf.c:152:3: warning: implicit declaration of function 'LIBXSMM_MEMZERO127' [-Wimplicit-function-declaration], and may break somewhere enables LIBXSMM_PERF_JITDUMP.