### PR TITLE
Fix vtune support bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -821,13 +821,14 @@ ifneq (,$(strip $(LIBJITPROFILING)))
 $(LIBJITPROFILING): $(BLDDIR)/jitprofiling/.make
 	@$(CP) $(VTUNEROOT)/lib64/libjitprofiling.$(SLIBEXT) $(BLDDIR)/jitprofiling
 	@cd $(BLDDIR)/jitprofiling; $(AR) x libjitprofiling.$(SLIBEXT)
+    JITPROFILINGOBJ := $(BLDDIR)/jitprofiling/jitprofiling.o
 endif
 
 .PHONY: clib
 clib: $(OUTDIR)/libxsmm-static.pc $(OUTDIR)/libxsmm-shared.pc
 ifeq (,$(filter-out 0 2,$(BUILD)))
 $(OUTDIR)/libxsmm.$(SLIBEXT): $(OUTDIR)/.make $(OBJFILES_LIB) $(OBJFILES_GEN_LIB) $(KRNOBJS) $(LIBJITPROFILING)
-	$(MAKE_AR) $(OUTDIR)/libxsmm.$(SLIBEXT) $(call tailwords,$^)
+	$(MAKE_AR) $(OUTDIR)/libxsmm.$(SLIBEXT) $(call tailwords,$^) $(JITPROFILINGOBJ)
 else
 .PHONY: $(OUTDIR)/libxsmm.$(SLIBEXT)
 endif


### PR DESCRIPTION
The jitprofiling.o should be archived into libxsmm.a

Without this fix, "make VERBOSE=1 SYM=1 VTUNEROOT=/opt/intel/vtune test -j160" will fail since symbols iJIT_IsProfilingActive etc. cannot be found.


