### PR TITLE
[Github Actions] Add test for AWS builder

### DIFF
--- a/.github/workflows/libxsmm-arm-graviton3.yml
+++ b/.github/workflows/libxsmm-arm-graviton3.yml
@@ -9,8 +9,26 @@ env:
   SYM: 2
 
 jobs:
+  ec2-start:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 2: Set up AWS CLI
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      # Step 3: Start EC2 instance
+      - name: Start EC2 instance
+        run: |
+          aws ec2 start-instances --instance-ids i-0133c8f6344ff0d86
+
   GEMM:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: GEMM
@@ -18,6 +36,7 @@ jobs:
 
   BCSC_SPMM:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: BCSC_SPMM
@@ -25,6 +44,7 @@ jobs:
 
   ELTWISE:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: ELTWISE
@@ -32,6 +52,7 @@ jobs:
 
   EQUATION:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: EQUATION
@@ -39,6 +60,7 @@ jobs:
 
   FSSPMDM:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: FSSPMDM
@@ -48,6 +70,7 @@ jobs:
 
   Test_4:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: TEST_4
@@ -55,6 +78,7 @@ jobs:
 
   Test_6:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: TEST_6
@@ -62,6 +86,7 @@ jobs:
 
   Test_11:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: TEST_11
@@ -69,6 +94,7 @@ jobs:
 
   Fortran:
     runs-on: [ self-hosted, graviton ]
+    needs: ec2-start
     steps:
       - uses: actions/checkout@v4
       - name: FORTRAN

--- a/.github/workflows/libxsmm-arm-graviton3.yml
+++ b/.github/workflows/libxsmm-arm-graviton3.yml
@@ -1,0 +1,75 @@
+name: LIBXSMM Arm Graviton 3
+
+on:
+  workflow_dispatch:
+  push:
+
+env:
+  LIBXSMM_VERBOSE: 4
+  SYM: 2
+
+jobs:
+  GEMM:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: GEMM
+        run: "scripts/tool_test.sh samples/xgemm/kernel_test.sh"
+
+  BCSC_SPMM:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: BCSC_SPMM
+        run: "scripts/tool_test.sh samples/spmm/kernel_test.sh"
+
+  ELTWISE:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: ELTWISE
+        run: "scripts/tool_test.sh samples/eltwise/run_test.sh"
+
+  EQUATION:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: EQUATION
+        run: "scripts/tool_test.sh samples/equation/run_test.sh"
+
+  FSSPMDM:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: FSSPMDM
+        run: |-
+          ENVS="LIBXSMM_FSSPMDM_HINT=1 LIBXSMM_FSSPMDM_HINT=2 LIBXSMM_FSSPMDM_HINT=3" \
+          TEST_N=48 scripts/tool_test.sh samples/pyfr/test.sh
+
+  Test_4:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: TEST_4
+        run: "scripts/tool_test.sh 4"
+
+  Test_6:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: TEST_6
+        run: "scripts/tool_test.sh 6"
+
+  Test_11:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: TEST_11
+        run: "scripts/tool_test.sh 11"
+
+  Fortran:
+    runs-on: [ self-hosted, graviton ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: FORTRAN
+        run: "scripts/tool_test.sh 5"


### PR DESCRIPTION
This is a temporary fix to move to Github Actions. It does not start/stop the instance automatically, this is left for later once we get the IAM/secret keys right, but it works as a temporary stop-gap for now.

I have added triggers for `workflow_dispatch` (ie. press the button on Github's web interface) and `push` (which also counts PRs). This means for now we still need to activate the instance whenever it runs, so we could keep only on `worflow_dispatch` and not `push`?

I don't mind either way.