### PR TITLE
removing b pointers fused address calculation for very small K

### DIFF
--- a/src/generator_gemm_avx2_microkernel.c
+++ b/src/generator_gemm_avx2_microkernel.c
@@ -384,12 +384,11 @@ void libxsmm_generator_gemm_avx2_microkernel_Amxfp4( libxsmm_generated_code*    
   }
 
   /* Increase B for next K iteration */
-  if ((32/l_k_pack_factor)/l_k_unroll_factor > 1 || i_k > 32) {
-    libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                 i_micro_kernel_config->alu_add_instruction,
-                                 i_gp_reg_mapping->gp_reg_b,
-                                 (long long)l_k_pack_factor*l_k_unroll_factor*i_micro_kernel_config->datatype_size_in2 );
-  }
+  libxsmm_x86_instruction_alu_imm( io_generated_code,
+                               i_micro_kernel_config->alu_add_instruction,
+                               i_gp_reg_mapping->gp_reg_b,
+                               (long long)l_k_pack_factor*l_k_unroll_factor*i_micro_kernel_config->datatype_size_in2 );
+
   if ((32/l_k_pack_factor)/l_k_unroll_factor > 1) {
     libxsmm_generator_generic_loop_footer_with_idx_inc( io_generated_code, i_micro_kernel_config->io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_0, 1, (32/l_k_pack_factor)/l_k_unroll_factor);
   }

--- a/src/generator_gemm_avx2_microkernel.c
+++ b/src/generator_gemm_avx2_microkernel.c
@@ -25,7 +25,7 @@ void libxsmm_generator_gemm_avx2_kloop_kernel( libxsmm_generated_code*          
   unsigned int l_k = 0;
   unsigned int l_k_pack_factor = 1;
   void (*l_generator_microkernel)(libxsmm_generated_code*, const libxsmm_gp_reg_mapping*, const libxsmm_micro_kernel_config*,
-                                  const libxsmm_gemm_descriptor*, const unsigned int, const unsigned int, const int);
+                                  const libxsmm_gemm_descriptor*, const unsigned int, const unsigned int);
 
   unsigned int l_is_Amxfp4_Bfp32_gemm = libxsmm_x86_is_Amxfp4_Bfp32_gemm(i_xgemm_desc);
   unsigned int l_is_Amxfp4_Bbf16_gemm = libxsmm_x86_is_Amxfp4_Bbf16_gemm(i_xgemm_desc);
@@ -35,9 +35,8 @@ void libxsmm_generator_gemm_avx2_kloop_kernel( libxsmm_generated_code*          
                                       ( ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_A_UNSIGNED) >  0) && ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_B_UNSIGNED) >  0) ) );
 
   if ( l_is_Amxfp4_Bfp32_gemm > 0 || l_is_Amxfp4_Bbf16_gemm > 0 || l_is_Amxfp4_Bi8_gemm > 0 ) {
-    l_generator_microkernel = libxsmm_generator_gemm_avx2_microkernel_Amxfp4;
-    l_generator_microkernel(io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
-                            i_xgemm_desc, i_m_blocking, i_n_blocking, i_k_blocking);
+    libxsmm_generator_gemm_avx2_microkernel_Amxfp4(io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
+                                                   i_xgemm_desc, i_m_blocking, i_n_blocking, i_k_blocking);
     return;
   }
 
@@ -67,8 +66,7 @@ void libxsmm_generator_gemm_avx2_kloop_kernel( libxsmm_generated_code*          
 
   for ( l_k = 0; l_k < i_k_blocking; l_k += l_k_pack_factor) {
     l_generator_microkernel(io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
-                            i_xgemm_desc, i_m_blocking, i_n_blocking,
-                            ( i_k_blocking == (unsigned int)i_xgemm_desc->k ) ? (int)l_k : -1);
+                            i_xgemm_desc, i_m_blocking, i_n_blocking);
   }
 }
 
@@ -490,13 +488,6 @@ void libxsmm_generator_gemm_avx2_microkernel_Amxfp4( libxsmm_generated_code*    
     /* End of K loop */
     libxsmm_generator_generic_loop_footer_with_idx_inc( io_generated_code, i_micro_kernel_config->io_loop_label_tracker, i_gp_reg_mapping->gp_reg_kloop, 32, i_k);
   }
-  /* Adjust reg_b */
-  if ((32/l_k_pack_factor)/l_k_unroll_factor > 1 || i_k > 32) {
-    libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                 i_micro_kernel_config->alu_sub_instruction,
-                                 i_gp_reg_mapping->gp_reg_b,
-                                 (long long)i_micro_kernel_config->datatype_size_in2*i_k );
-  }
 }
 
 LIBXSMM_API_INTERN
@@ -505,8 +496,7 @@ void libxsmm_generator_gemm_avx2_microkernel( libxsmm_generated_code*           
                                               const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                               const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                               const unsigned int                 i_m_blocking,
-                                              const unsigned int                 i_n_blocking,
-                                              const int                          i_offset )
+                                              const unsigned int                 i_n_blocking )
 {
   /* deriving register blocking from kernel config */
   unsigned int l_m_blocking = ( i_m_blocking % i_micro_kernel_config->vector_length == 0 ) ? i_m_blocking/i_micro_kernel_config->vector_length : (i_m_blocking/i_micro_kernel_config->vector_length)+1;
@@ -553,53 +543,36 @@ void libxsmm_generator_gemm_avx2_microkernel( libxsmm_generated_code*           
                                      i_gp_reg_mapping->gp_reg_a,
                                      (long long)i_xgemm_desc->lda*i_micro_kernel_config->datatype_size_in*l_k_pack_factor );
       }
-      /* different ways of using B */
-      if ( i_offset != (-1) ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset * i_xgemm_desc->ldb) + (l_n * i_micro_kernel_config->datatype_size_in);
-        } else {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-        }
 
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      i_micro_kernel_config->b_vmove_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
+      /* handle trans B */
+      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+        l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
       } else {
+        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
+      }
+
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+                                    i_micro_kernel_config->instruction_set,
+                                    i_micro_kernel_config->b_vmove_instruction,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                    l_b_offset,
+                                    i_micro_kernel_config->vector_name,
+                                    l_n, 0, 1, 0 );
+      if ( l_n == (i_n_blocking -1) ) {
         /* handle trans B */
         if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+          l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
         } else {
-          l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
+          l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
         }
 
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      i_micro_kernel_config->b_vmove_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
-        if ( l_n == (i_n_blocking -1) ) {
-          /* handle trans B */
-          if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-            l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
-          } else {
-            l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-          }
-
-          libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                       i_micro_kernel_config->alu_add_instruction,
-                                       i_gp_reg_mapping->gp_reg_b,
-                                       l_b_offset );
-        }
+        libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                     i_micro_kernel_config->alu_add_instruction,
+                                     i_gp_reg_mapping->gp_reg_b,
+                                     l_b_offset );
       }
+
       /* issue fma */
       if ( LIBXSMM_DATATYPE_I8 == LIBXSMM_GEMM_GETENUM_AB_COMMON_PREC( i_xgemm_desc->datatype ) ) {
         if ( ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_A_UNSIGNED) > 0) && ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_B_UNSIGNED) == 0) ) {
@@ -642,54 +615,34 @@ void libxsmm_generator_gemm_avx2_microkernel( libxsmm_generated_code*           
     }
   } else {
     /* broadcast from B -> into vec registers 0 to i_n_blocking */
-    if ( i_offset != (-1) ) {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset * i_xgemm_desc->ldb) + (l_n * i_micro_kernel_config->datatype_size_in);
-        } else {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-        }
-
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      i_micro_kernel_config->b_vmove_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
-      }
-    } else {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-        } else {
-          l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
-        }
-
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      i_micro_kernel_config->b_vmove_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
-      }
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
       /* handle trans B */
       if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-        l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+        l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
       } else {
-        l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
       }
 
-      libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                  i_micro_kernel_config->alu_add_instruction,
-                                  i_gp_reg_mapping->gp_reg_b,
-                                  l_b_offset );
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+                                    i_micro_kernel_config->instruction_set,
+                                    i_micro_kernel_config->b_vmove_instruction,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                    l_b_offset,
+                                    i_micro_kernel_config->vector_name,
+                                    l_n, 0, 1, 0 );
     }
+    /* handle trans B */
+    if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+      l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+    } else {
+      l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+    }
+
+    libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                i_micro_kernel_config->alu_add_instruction,
+                                i_gp_reg_mapping->gp_reg_b,
+                                l_b_offset );
 
     if (l_m_blocking == 4) {
       /* load column vectors of A and multiply with all broadcasted row entries of B */
@@ -832,8 +785,7 @@ void libxsmm_generator_gemm_avx2_microkernel_int8_int16_vnni_emu( libxsmm_genera
                                                                   const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                   const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                   const unsigned int                 i_m_blocking,
-                                                                  const unsigned int                 i_n_blocking,
-                                                                  const int                          i_offset )
+                                                                  const unsigned int                 i_n_blocking )
 {
   /* deriving register blocking from kernel config */
   unsigned int l_m_blocking = ( i_m_blocking % i_micro_kernel_config->vector_length == 0 ) ? i_m_blocking/i_micro_kernel_config->vector_length : (i_m_blocking/i_micro_kernel_config->vector_length)+1;
@@ -866,54 +818,34 @@ void libxsmm_generator_gemm_avx2_microkernel_int8_int16_vnni_emu( libxsmm_genera
   libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_SSE_AVX2_LP_HELPER_PTR, i_gp_reg_mapping->gp_reg_help_1 );
 
   /* broadcast from B -> into vec registers 0 to i_n_blocking */
-  if ( i_offset != (-1) ) {
-    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-      /* handle trans B */
-      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-        l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset * i_xgemm_desc->ldb) + (l_n * i_micro_kernel_config->datatype_size_in);
-      } else {
-        l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-      }
-
-      libxsmm_x86_instruction_vec_move( io_generated_code,
-                                    i_micro_kernel_config->instruction_set,
-                                    i_micro_kernel_config->b_vmove_instruction,
-                                    i_gp_reg_mapping->gp_reg_b,
-                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                    l_b_offset,
-                                    i_micro_kernel_config->vector_name,
-                                    l_n, 0, 1, 0 );
-    }
-  } else {
-    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-      /* handle trans B */
-      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-        l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-      } else {
-        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
-      }
-
-      libxsmm_x86_instruction_vec_move( io_generated_code,
-                                    i_micro_kernel_config->instruction_set,
-                                    i_micro_kernel_config->b_vmove_instruction,
-                                    i_gp_reg_mapping->gp_reg_b,
-                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                    l_b_offset,
-                                    i_micro_kernel_config->vector_name,
-                                    l_n, 0, 1, 0 );
-    }
+  for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
     /* handle trans B */
     if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-      l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+      l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
     } else {
-      l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+      l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
     }
 
-    libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                  i_micro_kernel_config->alu_add_instruction,
+    libxsmm_x86_instruction_vec_move( io_generated_code,
+                                  i_micro_kernel_config->instruction_set,
+                                  i_micro_kernel_config->b_vmove_instruction,
                                   i_gp_reg_mapping->gp_reg_b,
-                                  l_b_offset );
+                                  LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                  l_b_offset,
+                                  i_micro_kernel_config->vector_name,
+                                  l_n, 0, 1, 0 );
   }
+  /* handle trans B */
+  if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+    l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+  } else {
+    l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+  }
+
+  libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                i_micro_kernel_config->alu_add_instruction,
+                                i_gp_reg_mapping->gp_reg_b,
+                                l_b_offset );
 
   /* load column vectors of A and multiply with all broadcasted row entries of B */
   for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
@@ -990,8 +922,7 @@ void libxsmm_generator_gemm_avx2_microkernel_int8_uu_ss_vnni_emu( libxsmm_genera
                                                                   const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                   const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                   const unsigned int                 i_m_blocking,
-                                                                  const unsigned int                 i_n_blocking,
-                                                                  const int                          i_offset )
+                                                                  const unsigned int                 i_n_blocking )
 {
   /* deriving register blocking from kernel config */
   unsigned int l_m_blocking = ( i_m_blocking % i_micro_kernel_config->vector_length == 0 ) ? i_m_blocking/i_micro_kernel_config->vector_length : (i_m_blocking/i_micro_kernel_config->vector_length)+1;
@@ -1030,64 +961,40 @@ void libxsmm_generator_gemm_avx2_microkernel_int8_uu_ss_vnni_emu( libxsmm_genera
 
   for ( l_pass = 0; l_pass < 2; ++l_pass ) {
     /* broadcast from B -> into vec registers 0 to i_n_blocking */
-    if ( i_offset != (-1) ) {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset * i_xgemm_desc->ldb) + (l_n * i_micro_kernel_config->datatype_size_in);
-        } else {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-        }
-
-        if ( l_pass == 1 ) {
-          l_b_offset += 2;
-        }
-
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      LIBXSMM_X86_INSTR_VPBROADCASTW,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      'x',
-                                      l_n, 0, 1, 0 );
-      }
-    } else {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-        } else {
-          l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
-        }
-
-        if ( l_pass == 1 ) {
-          l_b_offset += 2;
-        }
-
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      LIBXSMM_X86_INSTR_VPBROADCASTW,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      'x',
-                                      l_n, 0, 1, 0 );
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+      /* handle trans B */
+      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+        l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+      } else {
+        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
       }
 
       if ( l_pass == 1 ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
-        } else {
-          l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-        }
-
-        libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                      i_micro_kernel_config->alu_add_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      l_b_offset );
+        l_b_offset += 2;
       }
+
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+                                    i_micro_kernel_config->instruction_set,
+                                    LIBXSMM_X86_INSTR_VPBROADCASTW,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                    l_b_offset,
+                                    'x',
+                                    l_n, 0, 1, 0 );
+    }
+
+    if ( l_pass == 1 ) {
+      /* handle trans B */
+      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+        l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+      } else {
+        l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+      }
+
+      libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                    i_micro_kernel_config->alu_add_instruction,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    l_b_offset );
     }
 
     for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
@@ -1284,8 +1191,7 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_emu( libxsmm_generated_co
                                                             const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                             const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                             const unsigned int                 i_m_blocking,
-                                                            const unsigned int                 i_n_blocking,
-                                                            const int                          i_offset )
+                                                            const unsigned int                 i_n_blocking )
 {
   /* deriving register blocking from kernel config */
   unsigned int l_m_blocking = ( i_m_blocking % i_micro_kernel_config->vector_length == 0 ) ? i_m_blocking/i_micro_kernel_config->vector_length : (i_m_blocking/i_micro_kernel_config->vector_length)+1;
@@ -1323,79 +1229,47 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_emu( libxsmm_generated_co
     libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VMOVUPS,
                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 0, 'y', i_n_blocking, 0, 0, 0 );
     /* broadcast from B -> into vec registers 0 to i_n_blocking */
-    if ( i_offset != (-1) ) {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset * i_xgemm_desc->ldb) + (l_n * i_micro_kernel_config->datatype_size_in);
-        } else {
-          l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-        }
-
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      i_micro_kernel_config->b_vmove_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
-
-        /* in the firs pass we conver the higher BF16 values to FP32; in the second the lower Bf16 values */
-        if ( l_pass == 0 ) {
-          libxsmm_x86_instruction_vec_compute_3reg( io_generated_code, LIBXSMM_X86_INSTR_VPANDD,
-                                                         i_micro_kernel_config->vector_name,
-                                                         l_n, i_n_blocking, l_n );
-
-        } else {
-          libxsmm_x86_instruction_vec_compute_2reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VPSLLD_I,
-                                                         i_micro_kernel_config->vector_name,
-                                                         l_n, l_n, 16 );
-        }
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+      /* handle trans B */
+      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+        l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
+      } else {
+        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
       }
-    } else {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = l_n * i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-        } else {
-          l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
-        }
 
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      i_micro_kernel_config->b_vmove_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+                                    i_micro_kernel_config->instruction_set,
+                                    i_micro_kernel_config->b_vmove_instruction,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                    l_b_offset,
+                                    i_micro_kernel_config->vector_name,
+                                    l_n, 0, 1, 0 );
 
-        /* in the firs pass we conver the higher BF16 values to FP32; in the second the lower Bf16 values */
-        if ( l_pass == 0 ) {
-          libxsmm_x86_instruction_vec_compute_3reg( io_generated_code, LIBXSMM_X86_INSTR_VPANDD,
-                                                         i_micro_kernel_config->vector_name,
-                                                         l_n, i_n_blocking, l_n );
+      /* in the firs pass we conver the higher BF16 values to FP32; in the second the lower Bf16 values */
+      if ( l_pass == 0 ) {
+        libxsmm_x86_instruction_vec_compute_3reg( io_generated_code, LIBXSMM_X86_INSTR_VPANDD,
+                                                       i_micro_kernel_config->vector_name,
+                                                       l_n, i_n_blocking, l_n );
 
-        } else {
-          libxsmm_x86_instruction_vec_compute_2reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VPSLLD_I,
-                                                         i_micro_kernel_config->vector_name,
-                                                         l_n, l_n, 16 );
-        }
+      } else {
+        libxsmm_x86_instruction_vec_compute_2reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VPSLLD_I,
+                                                       i_micro_kernel_config->vector_name,
+                                                       l_n, l_n, 16 );
       }
-      if ( l_pass == 1 ) {
-        /* handle trans B */
-        if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-          l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
-        } else {
-          l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-        }
-
-        libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                      i_micro_kernel_config->alu_add_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      l_b_offset );
+    }
+    if ( l_pass == 1 ) {
+      /* handle trans B */
+      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+        l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+      } else {
+        l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
       }
+
+      libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                    i_micro_kernel_config->alu_add_instruction,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    l_b_offset );
     }
 
     /* load column vectors of A and multiply with all broadcasted row entries of B */
@@ -1487,8 +1361,7 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_flat_emu( libxsmm_generated_co
                                                             const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                             const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                             const unsigned int                 i_m_blocking,
-                                                            const unsigned int                 i_n_blocking,
-                                                            const int                          i_offset )
+                                                            const unsigned int                 i_n_blocking )
 {
   /* deriving register blocking from kernel config */
   unsigned int l_m_blocking = ( i_m_blocking % i_micro_kernel_config->vector_length == 0 ) ? i_m_blocking/i_micro_kernel_config->vector_length : (i_m_blocking/i_micro_kernel_config->vector_length)+1;
@@ -1514,62 +1387,38 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_flat_emu( libxsmm_generated_co
   }
 
   /* broadcast from B -> into vec registers 0 to i_n_blocking */
-  if ( i_offset != (-1) ) {
-    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-      /* handle trans B */
-      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-        l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset * i_xgemm_desc->ldb) + (l_n * i_micro_kernel_config->datatype_size_in);
-      } else {
-        l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-      }
-
-      libxsmm_x86_instruction_vec_move( io_generated_code,
-                                        i_micro_kernel_config->instruction_set,
-                                        i_micro_kernel_config->b_vmove_instruction,
-                                        i_gp_reg_mapping->gp_reg_b,
-                                        LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                        l_b_offset,
-                                        i_micro_kernel_config->vector_name,
-                                        l_n, 0, 1, 0 );
-
-      libxsmm_x86_instruction_vec_compute_2reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VPSLLD_I,
-                                                     i_micro_kernel_config->vector_name,
-                                                     l_n, l_n, 16 );
-    }
-  } else {
-    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-      /* handle trans B */
-      if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-        l_b_offset = l_n * i_micro_kernel_config->datatype_size_in;
-      } else {
-        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
-      }
-
-      libxsmm_x86_instruction_vec_move( io_generated_code,
-                                        i_micro_kernel_config->instruction_set,
-                                        i_micro_kernel_config->b_vmove_instruction,
-                                        i_gp_reg_mapping->gp_reg_b,
-                                        LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                        l_b_offset,
-                                        i_micro_kernel_config->vector_name,
-                                        l_n, 0, 1, 0 );
-
-      libxsmm_x86_instruction_vec_compute_2reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VPSLLD_I,
-                                                     i_micro_kernel_config->vector_name,
-                                                     l_n, l_n, 16 );
-    }
+  for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
     /* handle trans B */
     if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
-      l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+      l_b_offset = l_n * i_micro_kernel_config->datatype_size_in;
     } else {
-      l_b_offset = i_micro_kernel_config->datatype_size_in;
+      l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
     }
 
-    libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                     i_micro_kernel_config->alu_add_instruction,
-                                     i_gp_reg_mapping->gp_reg_b,
-                                     l_b_offset );
+    libxsmm_x86_instruction_vec_move( io_generated_code,
+                                      i_micro_kernel_config->instruction_set,
+                                      i_micro_kernel_config->b_vmove_instruction,
+                                      i_gp_reg_mapping->gp_reg_b,
+                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                      l_b_offset,
+                                      i_micro_kernel_config->vector_name,
+                                      l_n, 0, 1, 0 );
+
+    libxsmm_x86_instruction_vec_compute_2reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VPSLLD_I,
+                                                   i_micro_kernel_config->vector_name,
+                                                   l_n, l_n, 16 );
   }
+  /* handle trans B */
+  if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ) {
+    l_b_offset = i_xgemm_desc->ldb * i_micro_kernel_config->datatype_size_in;
+  } else {
+    l_b_offset = i_micro_kernel_config->datatype_size_in;
+  }
+
+  libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                   i_micro_kernel_config->alu_add_instruction,
+                                   i_gp_reg_mapping->gp_reg_b,
+                                   l_b_offset );
 
   /* load column vectors of A and multiply with all broadcasted row entries of B */
   for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
@@ -1647,8 +1496,7 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_srf( libxsmm_generated_co
                                                             const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                             const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                             const unsigned int                 i_m_blocking,
-                                                            const unsigned int                 i_n_blocking,
-                                                            const int                          i_offset )
+                                                            const unsigned int                 i_n_blocking )
 {
   /* deriving register blocking from kernel config */
   unsigned int l_m_blocking = ( i_m_blocking % i_micro_kernel_config->vector_length == 0 ) ? i_m_blocking/i_micro_kernel_config->vector_length : (i_m_blocking/i_micro_kernel_config->vector_length)+1;
@@ -1690,42 +1538,26 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_srf( libxsmm_generated_co
 
   for ( l_pass = 0; l_pass < 2; ++l_pass ) {
     /* broadcast from B -> into vec registers 0 to i_n_blocking */
-    if ( i_offset != (-1) ) {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        l_b_offset = (i_micro_kernel_config->datatype_size_in * i_offset) + (i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in);
-        l_b_offset += (l_pass == 0) ? 2 : 0; /* we are emulating AVX512 VDPBF16PS */
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+      l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
+      l_b_offset += (l_pass == 0) ? 2 : 0; /* we are emulating AVX512 VDPBF16PS */
 
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      LIBXSMM_X86_INSTR_VBCSTNEBF162PS,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
-      }
-    } else {
-      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-        l_b_offset = i_xgemm_desc->ldb * l_n * i_micro_kernel_config->datatype_size_in;
-        l_b_offset += (l_pass == 0) ? 2 : 0; /* we are emulating AVX512 VDPBF16PS */
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+                                    i_micro_kernel_config->instruction_set,
+                                    LIBXSMM_X86_INSTR_VBCSTNEBF162PS,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    LIBXSMM_X86_GP_REG_UNDEF, 0,
+                                    l_b_offset,
+                                    i_micro_kernel_config->vector_name,
+                                    l_n, 0, 1, 0 );
+    }
+    if ( l_pass == 1 ) {
+      l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
 
-        libxsmm_x86_instruction_vec_move( io_generated_code,
-                                      i_micro_kernel_config->instruction_set,
-                                      LIBXSMM_X86_INSTR_VBCSTNEBF162PS,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      LIBXSMM_X86_GP_REG_UNDEF, 0,
-                                      l_b_offset,
-                                      i_micro_kernel_config->vector_name,
-                                      l_n, 0, 1, 0 );
-      }
-      if ( l_pass == 1 ) {
-        l_b_offset = i_micro_kernel_config->datatype_size_in * l_k_pack_factor;
-
-        libxsmm_x86_instruction_alu_imm( io_generated_code,
-                                      i_micro_kernel_config->alu_add_instruction,
-                                      i_gp_reg_mapping->gp_reg_b,
-                                      l_b_offset );
-      }
+      libxsmm_x86_instruction_alu_imm( io_generated_code,
+                                    i_micro_kernel_config->alu_add_instruction,
+                                    i_gp_reg_mapping->gp_reg_b,
+                                    l_b_offset );
     }
 
     /* load column vectors of A and multiply with all broadcasted row entries of B */

--- a/src/generator_gemm_avx2_microkernel.h
+++ b/src/generator_gemm_avx2_microkernel.h
@@ -38,8 +38,7 @@ void libxsmm_generator_gemm_avx2_microkernel( libxsmm_generated_code*           
                                               const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                               const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                               const unsigned int                 i_m_blocking,
-                                              const unsigned int                 i_n_blocking,
-                                              const int                          i_offset );
+                                              const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_avx2_microkernel_int8_int16_vnni_emu( libxsmm_generated_code*            io_generated_code,
@@ -47,8 +46,7 @@ void libxsmm_generator_gemm_avx2_microkernel_int8_int16_vnni_emu( libxsmm_genera
                                                                   const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                   const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                   const unsigned int                 i_m_blocking,
-                                                                  const unsigned int                 i_n_blocking,
-                                                                  const int                          i_offset );
+                                                                  const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_avx2_microkernel_int8_uu_ss_vnni_emu( libxsmm_generated_code*            io_generated_code,
@@ -56,8 +54,7 @@ void libxsmm_generator_gemm_avx2_microkernel_int8_uu_ss_vnni_emu( libxsmm_genera
                                                                   const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                   const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                   const unsigned int                 i_m_blocking,
-                                                                  const unsigned int                 i_n_blocking,
-                                                                  const int                          i_offset );
+                                                                  const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_emu( libxsmm_generated_code*            io_generated_code,
@@ -65,8 +62,7 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_emu( libxsmm_generated_co
                                                             const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                             const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                             const unsigned int                 i_m_blocking,
-                                                            const unsigned int                 i_n_blocking,
-                                                            const int                          i_offset );
+                                                            const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_avx2_microkernel_bf16_flat_emu( libxsmm_generated_code*            io_generated_code,
@@ -74,8 +70,7 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_flat_emu( libxsmm_generated_co
                                                             const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                             const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                             const unsigned int                 i_m_blocking,
-                                                            const unsigned int                 i_n_blocking,
-                                                            const int                          i_offset );
+                                                            const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_srf( libxsmm_generated_code*            io_generated_code,
@@ -83,8 +78,7 @@ void libxsmm_generator_gemm_avx2_microkernel_bf16_vnni_srf( libxsmm_generated_co
                                                             const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                             const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                             const unsigned int                 i_m_blocking,
-                                                            const unsigned int                 i_n_blocking,
-                                                            const int                          i_offset );
+                                                            const unsigned int                 i_n_blocking );
 
 #endif /* GENERATOR_GEMM_AVX2_MICROKERNEL_H */
 

--- a/src/generator_gemm_avx512_microkernel.h
+++ b/src/generator_gemm_avx512_microkernel.h
@@ -27,48 +27,42 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_nofsdbcst( lib
                                                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                              const unsigned int                 i_m_blocking,
-                                                                             const unsigned int                 i_n_blocking,
-                                                                             const int                          i_offset );
+                                                                             const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_m8_nofsdbcst( libxsmm_generated_code*            io_generated_code,
                                                                                       const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
                                                                                       const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                                       const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                                       const unsigned int                 i_m_blocking,
-                                                                                      const unsigned int                 i_n_blocking,
-                                                                                      const int                          i_offset );
+                                                                                      const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_i8_ss_uu_emu_nofsdbcst( libxsmm_generated_code*            io_generated_code,
                                                                                           const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
                                                                                           const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                                           const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                                           const unsigned int                 i_m_blocking,
-                                                                                          const unsigned int                 i_n_blocking,
-                                                                                          const int                          i_offset );
+                                                                                          const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_m8_i8_ss_uu_emu_nofsdbcst( libxsmm_generated_code*            io_generated_code,
                                                                                              const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
                                                                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                                              const unsigned int                 i_m_blocking,
-                                                                                             const unsigned int                 i_n_blocking,
-                                                                                             const int                          i_offset );
+                                                                                             const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_bf16_emu_nofsdbcst( libxsmm_generated_code*            io_generated_code,
                                                                                       const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
                                                                                       const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                                       const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                                       const unsigned int                 i_m_blocking,
-                                                                                      const unsigned int                 i_n_blocking,
-                                                                                      const int                          i_offset );
+                                                                                      const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_m8_bf16_emu_nofsdbcst( libxsmm_generated_code*            io_generated_code,
                                                                                          const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
                                                                                          const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                                          const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                                          const unsigned int                 i_m_blocking,
-                                                                                         const unsigned int                 i_n_blocking,
-                                                                                         const int                          i_offset );
+                                                                                         const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_avx512_microkernel_fsdbcst( libxsmm_generated_code*            io_generated_code,
                                                                            const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,

--- a/src/generator_gemm_avx_microkernel.h
+++ b/src/generator_gemm_avx_microkernel.h
@@ -28,8 +28,7 @@ void libxsmm_generator_gemm_avx_microkernel( libxsmm_generated_code*            
                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                              const unsigned int                 i_m_blocking,
-                                             const unsigned int                 i_n_blocking,
-                                             const int                          i_offset );
+                                             const unsigned int                 i_n_blocking );
 
 #endif /* GENERATOR_GEMM_AVX_MICROKERNEL_H */
 

--- a/src/generator_gemm_sse_microkernel.h
+++ b/src/generator_gemm_sse_microkernel.h
@@ -29,8 +29,7 @@ void libxsmm_generator_gemm_sse_microkernel( libxsmm_generated_code*            
                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                              const unsigned int                 i_m_blocking,
-                                             const unsigned int                 i_n_blocking,
-                                             const int                          i_offset );
+                                             const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_sse_microkernel_int8_uu_ss_vnni_emu( libxsmm_generated_code*            io_generated_code,
@@ -38,8 +37,7 @@ void libxsmm_generator_gemm_sse_microkernel_int8_uu_ss_vnni_emu( libxsmm_generat
                                                                  const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                                  const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                                  const unsigned int                 i_m_blocking,
-                                                                 const unsigned int                 i_n_blocking,
-                                                                 const int                          i_offset );
+                                                                 const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_sse_microkernel_bf16_vnni_emu( libxsmm_generated_code*            io_generated_code,
@@ -47,8 +45,7 @@ void libxsmm_generator_gemm_sse_microkernel_bf16_vnni_emu( libxsmm_generated_cod
                                                            const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                            const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                            const unsigned int                 i_m_blocking,
-                                                           const unsigned int                 i_n_blocking,
-                                                           const int                          i_offset );
+                                                           const unsigned int                 i_n_blocking );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_sse_microkernel_bf16_flat_emu( libxsmm_generated_code*            io_generated_code,
@@ -56,8 +53,7 @@ void libxsmm_generator_gemm_sse_microkernel_bf16_flat_emu( libxsmm_generated_cod
                                                            const libxsmm_micro_kernel_config* i_micro_kernel_config,
                                                            const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                            const unsigned int                 i_m_blocking,
-                                                           const unsigned int                 i_n_blocking,
-                                                           const int                          i_offset );
+                                                           const unsigned int                 i_n_blocking );
 
 #endif /* GENERATOR_GEMM_SSE_MICROKERNEL_H */
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_remove_knl_optimization_in_x86_gemmkernel-1.17-3762
+fix_remove_knl_optimization_in_x86_gemmkernel-1.17-3763

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_riscv_rvv_initial_support-1.17-3883
+fix_remove_knl_optimization_in_x86_gemmkernel-1.17-3762


### PR DESCRIPTION
For very small K (<24) the x86 code generators avoid on GPR add per M/N block. It was not measurable that this give any performance benefit, but it complicates code generation and increases code to maintain. This PR removes this optimization.  


