### PR TITLE
Fixed vector length initialization for nonunit lmul

### DIFF
--- a/src/generator_gemm_common_rv64.c
+++ b/src/generator_gemm_common_rv64.c
@@ -437,7 +437,7 @@ unsigned int libxsmm_generator_gemm_rv64_get_initial_m_blocking( libxsmm_micro_k
     } else if ( i_xgemm_desc->m >= 4 ) {
       l_m_blocking = 4;
     } else{
-      l_m_blocking = i_xgemm_desc->m;
+      l_m_blocking = i_xgemm_desc->m % 4;
     }
   } else if ( ( i_arch >= LIBXSMM_RV64_MVL128 ) && ( LIBXSMM_DATATYPE_F64 == LIBXSMM_GEMM_GETENUM_AB_COMMON_PREC( i_xgemm_desc->datatype ) ) ) {
     /* TODO: check if there is a better blocking strategy */
@@ -484,7 +484,7 @@ unsigned int libxsmm_generator_gemm_rv64_update_m_blocking( libxsmm_micro_kernel
         l_m_blocking = 4;
       }
       else {
-        l_m_blocking = i_xgemm_desc->m;
+        l_m_blocking = i_xgemm_desc->m % 4;
       }
     } else if (i_current_m_blocking == 16 ) {
       if ((i_xgemm_desc->m % 16) >= 8){
@@ -494,7 +494,7 @@ unsigned int libxsmm_generator_gemm_rv64_update_m_blocking( libxsmm_micro_kernel
         l_m_blocking = 4;
       }
       else {
-        l_m_blocking = i_xgemm_desc->m;
+        l_m_blocking = i_xgemm_desc->m % 4;
       }
     } else if (i_current_m_blocking == 8 ) {
       if ((i_xgemm_desc->m % 8) >= 4){

--- a/src/generator_mateltwise_rv64.c
+++ b/src/generator_mateltwise_rv64.c
@@ -28,6 +28,8 @@ void libxsmm_generator_mateltwise_rv64_update_micro_kernel_config_vectorlength( 
        io_generated_code->arch == LIBXSMM_AARCH64_SVE512 ||
        io_generated_code->arch == LIBXSMM_RV64_MVL128 ||
        io_generated_code->arch == LIBXSMM_RV64_MVL256 ||
+       io_generated_code->arch == LIBXSMM_RV64_MVL128_LMUL ||
+       io_generated_code->arch == LIBXSMM_RV64_MVL256_LMUL ||
        io_generated_code->arch == LIBXSMM_AARCH64_A64FX ) {
     io_micro_kernel_config->instruction_set = io_generated_code->arch;
     io_micro_kernel_config->vector_reg_count = 32;

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_fix_nonunit_lmul-1.17-3771
+feature_fix_eltwise_nonunit_lmul-1.17-3772


### PR DESCRIPTION
Eltwise kernel was crashing in convolution tests due to uninitialized vector length for nonunit lmul. 