### PR TITLE
Fix usage of deprecated MELTW unary type in Conv1dOpti.cpp

### DIFF
--- a/samples/deeplearning/conv1dopti_layer/Conv1dOpti-extension/Conv1dOpti.cpp
+++ b/samples/deeplearning/conv1dopti_layer/Conv1dOpti-extension/Conv1dOpti.cpp
@@ -132,9 +132,9 @@ at::Tensor Conv1dOpti_forward_bf16_libxsmm(at::Tensor& input, at::Tensor& weight
 
     libxsmm_meltw_unary_type trans_vnni_type;
     if ( C_t % 2 == 1 ) {
-        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI_PAD;
+        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI8_PAD;
     } else {
-        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI;
+        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI8;
     }
     tpp_m1 = (XS_TILE_FORWARD + dial*(WW_t-1));
     tpp_m2 = (W_t - tile_multiple + dial*(WW_t-1));
@@ -431,9 +431,9 @@ std::tuple<at::Tensor, at::Tensor> Conv1dOpti_backward_bf16_libxsmm(at::Tensor& 
 
     libxsmm_meltw_unary_type trans_vnni_type;
     if ( F_t % 2 == 1 ) {
-        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI_PAD;
+        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI8_PAD;
     } else {
-        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI;
+        trans_vnni_type = LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI8;
     }
 
     tpp_m1 = (XS_TILE_DBACKWARD + dial*(WW_t-1));


### PR DESCRIPTION
Bug fix: Updated legacy usage of LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI_PAD which has been removed in the latest LIBXSMM version.

Fix: Replaced it with LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI8_PAD as per the current libxsmm_typedefs.h.