### PR TITLE
Feature prefetch ab

### DIFF
--- a/include/libxsmm_cpuid.h
+++ b/include/libxsmm_cpuid.h
@@ -125,4 +125,22 @@ LIBXSMM_API int libxsmm_cpuid_vlen32(int id);
 
 LIBXSMM_API int libxsmm_cpuid_rv64(libxsmm_cpuid_info* LIBXSMM_ARGDEF(info, NULL));
 
+/* Get reuse A knob */
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_a(void);
+
+/* Get reuse B knob */
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_b(void);
+
+/* Get reuse C knob */
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_c(void);
+
+/* Get prefetch A knob */
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_a(void);
+
+/* Get prefetch B knob */
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_b(void);
+
+/* Get prefetch stride of A knob */
+LIBXSMM_API unsigned int libxsmm_gemm_m_prefetch_stride(void);
+
 #endif /*LIBXSMM_CPUID_H*/

--- a/include/libxsmm_cpuid.h
+++ b/include/libxsmm_cpuid.h
@@ -126,21 +126,21 @@ LIBXSMM_API int libxsmm_cpuid_vlen32(int id);
 LIBXSMM_API int libxsmm_cpuid_rv64(libxsmm_cpuid_info* LIBXSMM_ARGDEF(info, NULL));
 
 /* Get reuse A knob */
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_a(void);
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_reuse_a(void);
 
 /* Get reuse B knob */
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_b(void);
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_reuse_b(void);
 
 /* Get reuse C knob */
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_c(void);
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_reuse_c(void);
 
 /* Get prefetch A knob */
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_a(void);
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_a(void);
 
 /* Get prefetch B knob */
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_b(void);
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_b(void);
 
 /* Get prefetch stride of A knob */
-LIBXSMM_API unsigned int libxsmm_gemm_m_prefetch_stride(void);
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_m_prefetch_stride(void);
 
 #endif /*LIBXSMM_CPUID_H*/

--- a/src/generator_gemm_rv64.c
+++ b/src/generator_gemm_rv64.c
@@ -18,11 +18,11 @@
 
 #define MAX_FP_REG (20)
 #define MAX_UIMM   (0x7ff)
-#define REUSE_A    (libxsmm_gemm_prefetch_reuse_a())
-#define REUSE_B    (libxsmm_gemm_prefetch_reuse_b())
-#define REUSE_C    (libxsmm_gemm_prefetch_reuse_c())
-#define PREFETCH_A (libxsmm_gemm_prefetch_a())
-#define PREFETCH_B (libxsmm_gemm_prefetch_b())
+#define REUSE_A    (libxsmm_cpuid_rv64_gemm_prefetch_reuse_a())
+#define REUSE_B    (libxsmm_cpuid_rv64_gemm_prefetch_reuse_b())
+#define REUSE_C    (libxsmm_cpuid_rv64_gemm_prefetch_reuse_c())
+#define PREFETCH_A (libxsmm_cpuid_rv64_gemm_prefetch_a())
+#define PREFETCH_B (libxsmm_cpuid_rv64_gemm_prefetch_b())
 #define REG_GP(i)  (((i)->arch == LIBXSMM_RV64_MVL128_LMUL) || (((i)->arch == LIBXSMM_RV64_MVL128_LMUL)))
 
 LIBXSMM_API_INTERN
@@ -159,7 +159,7 @@ void libxsmm_generator_gemm_rv64_microkernel_rvv( libxsmm_generated_code*       
   for (nld = 0; nld < max_loads; nld++){
     for ( l_m = 0; l_m < l_m_blocks[0]; l_m += i_reg_gp ) {
       if (PREFETCH_A){
-        int m_stride = libxsmm_gemm_m_prefetch_stride();
+        int m_stride = libxsmm_cpuid_rv64_gemm_m_prefetch_stride();
         int stride = i_xgemm_desc->lda * i_micro_kernel_config->datatype_size_in;
 
         /* If m_stride is set prefetch next m block else next k iteration of current m block */

--- a/src/generator_gemm_rv64.c
+++ b/src/generator_gemm_rv64.c
@@ -18,6 +18,11 @@
 
 #define MAX_FP_REG (20)
 #define MAX_UIMM   (0x7ff)
+#define REUSE_A    (libxsmm_gemm_prefetch_reuse_a())
+#define REUSE_B    (libxsmm_gemm_prefetch_reuse_b())
+#define REUSE_C    (libxsmm_gemm_prefetch_reuse_c())
+#define PREFETCH_A (libxsmm_gemm_prefetch_a())
+#define PREFETCH_B (libxsmm_gemm_prefetch_b())
 #define REG_GP(i)  (((i)->arch == LIBXSMM_RV64_MVL128_LMUL) || (((i)->arch == LIBXSMM_RV64_MVL128_LMUL)))
 
 LIBXSMM_API_INTERN

--- a/src/generator_gemm_rv64.c
+++ b/src/generator_gemm_rv64.c
@@ -228,7 +228,7 @@ void libxsmm_generator_gemm_rv64_microkernel_rvv( libxsmm_generated_code*       
       /* Calculate prefetch address for A from acutal address */
       libxsmm_rv64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_RV64_INSTR_GP_ADD,
           i_gp_reg_mapping->gp_reg_b, i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_b_prefetch,
-          i_micro_kernel_config->vector_length * i_micro_kernel_config->datatype_size_in);
+          (long long)i_micro_kernel_config->vector_length * i_micro_kernel_config->datatype_size_in);
 
       /* Prefetch A for next k loop */
       libxsmm_rv64_instruction_prefetch( io_generated_code, LIBXSMM_RV64_INSTR_GP_PREFETCH_R, i_gp_reg_mapping->gp_reg_b_prefetch, 0 );

--- a/src/libxsmm_cpuid_rv64.c
+++ b/src/libxsmm_cpuid_rv64.c
@@ -54,38 +54,38 @@ LIBXSMM_API int libxsmm_cpuid_rv64(libxsmm_cpuid_info* info)
   return mvl;
 }
 
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_a(void){
-  const char *const env_gemm_prefetch_reuse_a = getenv("LIBXSMM_GEMM_PREFETCH_REUSE_A");
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_reuse_a(void){
+  const char *const env_gemm_prefetch_reuse_a = getenv("LIBXSMM_RV64_GEMM_PREFETCH_REUSE_A");
   unsigned int result = (env_gemm_prefetch_reuse_a == 0) ? 0 : atoi(env_gemm_prefetch_reuse_a);
   return result;
 }
 
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_b(void){
-  const char *const env_gemm_prefetch_reuse_b = getenv("LIBXSMM_GEMM_PREFETCH_REUSE_B");
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_reuse_b(void){
+  const char *const env_gemm_prefetch_reuse_b = getenv("LIBXSMM_RV64_GEMM_PREFETCH_REUSE_B");
   unsigned int result = (env_gemm_prefetch_reuse_b == 0) ? 0 : atoi(env_gemm_prefetch_reuse_b);
   return result;
 }
 
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_c(void){
-  const char *const env_gemm_prefetch_reuse_c = getenv("LIBXSMM_GEMM_PREFETCH_REUSE_C");
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_reuse_c(void){
+  const char *const env_gemm_prefetch_reuse_c = getenv("LIBXSMM_RV64_GEMM_PREFETCH_REUSE_C");
   unsigned int result = (env_gemm_prefetch_reuse_c == 0) ? 0 : atoi(env_gemm_prefetch_reuse_c);
   return result;
 }
 
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_a(void){
-  const char *const env_gemm_prefetch_a = getenv("LIBXSMM_GEMM_PREFETCH_A");
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_a(void){
+  const char *const env_gemm_prefetch_a = getenv("LIBXSMM_RV64_GEMM_PREFETCH_A");
   unsigned int result = (env_gemm_prefetch_a == 0) ? 0 : atoi(env_gemm_prefetch_a);
   return result;
 }
 
-LIBXSMM_API unsigned int libxsmm_gemm_prefetch_b(void){
-  const char *const env_gemm_prefetch_b = getenv("LIBXSMM_GEMM_PREFETCH_B");
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_prefetch_b(void){
+  const char *const env_gemm_prefetch_b = getenv("LIBXSMM_RV64_GEMM_PREFETCH_B");
   unsigned int result = (env_gemm_prefetch_b == 0) ? 0 : atoi(env_gemm_prefetch_b);
   return result;
 }
 
-LIBXSMM_API unsigned int libxsmm_gemm_m_prefetch_stride(void){
-  const char *const env_gemm_m_prefetch_stride = getenv("LIBXSMM_GEMM_M_PREFETCH_STRIDE");
+LIBXSMM_API unsigned int libxsmm_cpuid_rv64_gemm_m_prefetch_stride(void){
+  const char *const env_gemm_m_prefetch_stride = getenv("LIBXSMM_RV64_GEMM_M_PREFETCH_STRIDE");
   unsigned int result = (env_gemm_m_prefetch_stride == 0) ? 0 : atoi(env_gemm_m_prefetch_stride);
   return result;
 }

--- a/src/libxsmm_cpuid_rv64.c
+++ b/src/libxsmm_cpuid_rv64.c
@@ -53,3 +53,41 @@ LIBXSMM_API int libxsmm_cpuid_rv64(libxsmm_cpuid_info* info)
 
   return mvl;
 }
+
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_a(void){
+  const char *const env_gemm_prefetch_reuse_a = getenv("LIBXSMM_GEMM_PREFETCH_REUSE_A");
+  unsigned int result = (env_gemm_prefetch_reuse_a == 0) ? 0 : atoi(env_gemm_prefetch_reuse_a);
+  return result;
+}
+
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_b(void){
+  const char *const env_gemm_prefetch_reuse_b = getenv("LIBXSMM_GEMM_PREFETCH_REUSE_B");
+  unsigned int result = (env_gemm_prefetch_reuse_b == 0) ? 0 : atoi(env_gemm_prefetch_reuse_b);
+  return result;
+}
+
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_reuse_c(void){
+  const char *const env_gemm_prefetch_reuse_c = getenv("LIBXSMM_GEMM_PREFETCH_REUSE_C");
+  unsigned int result = (env_gemm_prefetch_reuse_c == 0) ? 0 : atoi(env_gemm_prefetch_reuse_c);
+  return result;
+}
+
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_a(void){
+  const char *const env_gemm_prefetch_a = getenv("LIBXSMM_GEMM_PREFETCH_A");
+  unsigned int result = (env_gemm_prefetch_a == 0) ? 0 : atoi(env_gemm_prefetch_a);
+  return result;
+}
+
+LIBXSMM_API unsigned int libxsmm_gemm_prefetch_b(void){
+  const char *const env_gemm_prefetch_b = getenv("LIBXSMM_GEMM_PREFETCH_B");
+  unsigned int result = (env_gemm_prefetch_b == 0) ? 0 : atoi(env_gemm_prefetch_b);
+  return result;
+}
+
+LIBXSMM_API unsigned int libxsmm_gemm_m_prefetch_stride(void){
+  const char *const env_gemm_m_prefetch_stride = getenv("LIBXSMM_GEMM_M_PREFETCH_STRIDE");
+  unsigned int result = (env_gemm_m_prefetch_stride == 0) ? 0 : atoi(env_gemm_m_prefetch_stride);
+  return result;
+}
+
+#undef VLMAX

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_prefetch_ab-1.17-3775
+feature_prefetch_ab-1.17-3776

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_prefetch_ab-1.17-3777
+feature_prefetch_ab-1.17-3778

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_fix_eltwise_nonunit_lmul-1.17-3772
+feature_prefetch_ab-1.17-3775

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_prefetch_ab-1.17-3776
+feature_prefetch_ab-1.17-3777


### PR DESCRIPTION
Added support for Prefetch A matrix. 

This can be enabled using the env variable LIBXSMM_GEMM_PREFETCH_A. Prefetch distance can be set using LIBXSMM_GEMM_M_PREFETCH_STRIDE. There are few other variables to do ideal case studies.

