### PR TITLE
Use NEON generator for spgemm on Mac M4

### DIFF
--- a/src/generator_spgemm.c
+++ b/src/generator_spgemm.c
@@ -125,8 +125,9 @@ void libxsmm_generator_spgemm_csr_reg_kernel( libxsmm_generated_code*        io_
       libxsmm_generator_spgemm_csr_asparse_reg_x86( io_generated_code, i_xgemm_desc,
                                                     i_row_idx, i_column_idx, i_values );
     /* aarch64 without SVE */
-    } else if ( io_generated_code->arch >= LIBXSMM_AARCH64_V81 &&
-                io_generated_code->arch < LIBXSMM_AARCH64_SVE128 ) {
+    } else if ( ( io_generated_code->arch >= LIBXSMM_AARCH64_V81 &&
+                  io_generated_code->arch < LIBXSMM_AARCH64_SVE128 ) ||
+                  io_generated_code->arch == LIBXSMM_AARCH64_APPL_M4 ) {
       libxsmm_generator_spgemm_csr_asparse_reg_aarch64_neon( io_generated_code, i_xgemm_desc,
                                                              i_row_idx, i_column_idx, i_values );
     /* aarch64 with SVE */

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_prefetch_ab-1.17-3778
+main-16334


### PR DESCRIPTION
The M4 CPU supports only the streaming mode SVE, which restricts the execution of SVE instructions to streaming mode exclusively. Current `libxsmm_generator_spgemm_csr_asparse_reg_aarch64_sve` generates SVE instructions without inserting the required `smstart` and `smstop` instructions, leading to illegal instruction errors. 

By manually adding `smstart` before the first SVE instruction and `smstop` after the last, most errors are avoided when running `test.sh` under `samples/pyfr`. However, several test cases still fail result verification.

The testing shows that the performance of SVE on the M4 CPU is lower than that of  NEON. The reason may be that the SVE is implemented very inefficiently on the SME coprocessor. As a result, using the NEON generator directly is a more efficient choice.