### PR TITLE
Fixed BRGEMM execution for SME

### DIFF
--- a/samples/xgemm/gemm_kernel.c
+++ b/samples/xgemm/gemm_kernel.c
@@ -3343,13 +3343,21 @@ int main(int argc, char* argv []) {
   if ( l_file_input != 0 ) {
     l_file_handle = fopen( l_file_name, "r" );
   } else {
-    if ( l_trans_b == 0 ) {
+    if ( l_trans_a == 0 && l_trans_b == 0 ) {
       printf("------------------------------------------------\n");
       printf("RUNNING (%ix%i) X (%ix%i) = (%ix%i)\na:%s, b:%s, comp:%s, c:%s, BR=%i\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt, l_br);
       printf("------------------------------------------------\n");
-    } else {
+    } else if ( l_trans_a == 1 && l_trans_b == 0 ) {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i)^T X (%ix%i) = (%ix%i)\na:%s, b:%s, comp:%s, c:%s, BR=%i\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt, l_br);
+      printf("------------------------------------------------\n");
+    } else if ( l_trans_a == 0 && l_trans_b == 1 ) {
       printf("------------------------------------------------\n");
       printf("RUNNING (%ix%i) X (%ix%i)^T = (%ix%i)\na:%s, b:%s, comp:%s, c:%s, BR=%i\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt, l_br);
+      printf("------------------------------------------------\n");
+    } else {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i)^T X (%ix%i)^T = (%ix%i)\na:%s, b:%s, comp:%s, c:%s, BR=%i\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt, l_br);
       printf("------------------------------------------------\n");
     }
   }

--- a/samples/xgemm_sparse/spmm_kernel.c
+++ b/samples/xgemm_sparse/spmm_kernel.c
@@ -886,9 +886,23 @@ int main(int argc, char* argv []) {
   if ( l_file_input != 0 ) {
     l_file_handle = fopen( l_file_name, "r" );
   } else {
-    printf("------------------------------------------------\n");
-    printf("RUNNING (%ix%i) X (%ix%i) = (%ix%i)\na:%s, b:%s, comp:%s, c:%s\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt);
-    printf("------------------------------------------------\n");
+    if ( l_trans_a == 0 && l_trans_b == 0 ) {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i) X (%ix%i) = (%ix%i)\na:%s, b:%s, comp:%s, c:%s\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt);
+      printf("------------------------------------------------\n");
+    } else if ( l_trans_a == 1 && l_trans_b == 0 ) {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i)^T X (%ix%i) = (%ix%i)\na:%s, b:%s, comp:%s, c:%s\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt);
+      printf("------------------------------------------------\n");
+    } else if ( l_trans_a == 0 && l_trans_b == 1 ) {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i) X (%ix%i)^T = (%ix%i)\na:%s, b:%s, comp:%s, c:%s\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt);
+      printf("------------------------------------------------\n");
+    } else {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i)^T X (%ix%i)^T = (%ix%i)\na:%s, b:%s, comp:%s, c:%s\n", l_m, l_k, l_k, l_n, l_m, l_n, l_a_dt, l_b_dt, l_comp_dt, l_c_dt);
+      printf("------------------------------------------------\n");
+    }
   }
 
   do {

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -970,9 +970,11 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   } else if ( io_generated_code->arch == LIBXSMM_AARCH64_APPL_M4 ) {
     if( LIBXSMM_DATATYPE_F32 == LIBXSMM_GEMM_GETENUM_AB_COMMON_PREC(l_xgemm_desc_mod.datatype) &&
         ((i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI ) ||
-         (i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B )) ){
+         (i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B ) ||
+        (i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE ) ) ){
       libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( io_generated_code, &l_xgemm_desc_mod );
     } else {
+      io_generated_code->arch = LIBXSMM_AARCH64_V81;
       libxsmm_generator_gemm_aarch64_kernel( io_generated_code, &l_xgemm_desc_mod );
     }
   } else if ( io_generated_code->arch >= LIBXSMM_RV64_MVL128 ) {


### PR DESCRIPTION
SME-BRGEMM is only possible when B is transposed and strides are used for reduction. 
The fallback to NEON isn’t pretty, but I didn’t find a better solution for now.

Minor change: added the A^T flag to the xgemm test output.