### PR TITLE
Fix cmdline printing to handle NULL argv

### DIFF
--- a/src/libxsmm_main.c
+++ b/src/libxsmm_main.c
@@ -3999,7 +3999,7 @@ LIBXSMM_API_INTERN int libxsmm_print_cmdline(void* buffer, size_t buffer_size, c
   argv = (NULL != _NSGetArgv() ? *_NSGetArgv() : NULL);
   argc = (NULL != _NSGetArgc() ? *_NSGetArgc() : 0);
 # endif
-  if (0 < argc) {
+  if (0 < argc && NULL != argv && NULL != argv[0]) {
     int i = 1;
     if (NULL != prefix && '\0' != *prefix) {
 # if defined(_WIN32)


### PR DESCRIPTION
**Issue:** When using Intel VTune Profiler on Windows with `-DLIBXSMM_VTUNE=2` (to enable the VTune JIT notify API), libxsmm crashes and triggers a SIGSEGV.

**Root Cause:** Libxsmm's SIGSEGV handler calls `internal_finalize()`, which then triggers `libxsmm_print_cmdline()`. In this function, the code assumes `__argv != NULL`. However, when launched in specific environments like VTune profiling, `__argc` might be `> 0` while `__argv` is `NULL`.

Because this happens inside the error-handling path, it results in a recursive crash. This secondary crash masks the original error message.

**Fix:** Added a `NULL` check for `__argv` before attempting to print the command line.

**Verification:**

*Before this fix (original error is hidden):*

```
LIBXSMM_VERSION: unconfigured (2147483647) 
LIBXSMM_TARGET: srf
Registry and code: 13 MB
Command (PID=8876):vtune: Collection stopped.
```

*After this fix (original assertion failure is properly exposed):*

```
LIBXSMM_VERSION: unconfigured (2147483647)
LIBXSMM_TARGET: srf
Registry and code: 13 MB
Command (PID=26608): Uptime: 0.003800 s
Assertion failed: thread_manager_impl:473: (blocked == tpss_tls_op_err_ok) : . Please contact the technical support. vtune: Error: Assertion failed: thread_manager_impl:473: (blocked == tpss_tls_op_err_ok) : . Please contact the technical support.
vtune: Collection stopped.
```