### PR TITLE
Improve CMake package support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,15 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 set(LIBXSMM_VERSION "1.17")
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/version.txt")
-  file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/version.txt" LIBXSMM_VERSION_TXT LIMIT_COUNT 1)
-  string(REGEX MATCH "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" LIBXSMM_VERSION_MATCH "${LIBXSMM_VERSION_TXT}")
-  if(LIBXSMM_VERSION_MATCH)
-    set(LIBXSMM_VERSION_MAJOR "${CMAKE_MATCH_1}")
-    set(LIBXSMM_VERSION_MINOR "${CMAKE_MATCH_2}")
-    if(CMAKE_MATCH_4)
-      set(LIBXSMM_VERSION_UPDATE "${CMAKE_MATCH_4}")
-    else()
-      set(LIBXSMM_VERSION_UPDATE "0")
-    endif()
-    set(LIBXSMM_VERSION "${LIBXSMM_VERSION_MAJOR}.${LIBXSMM_VERSION_MINOR}.${LIBXSMM_VERSION_UPDATE}")
-  endif()
-endif()
 
-project(libxsmm VERSION ${LIBXSMM_VERSION} LANGUAGES C CXX)
+project(libxsmm
+  VERSION ${LIBXSMM_VERSION}
+  DESCRIPTION "Library for specialized dense and sparse matrix operations and deep learning primitives"
+  LANGUAGES C CXX)
+
+message(WARNING
+  "CMake is not the reference build system for LIBXSMM yet; "
+  "GNU Make remains the tested and preferred build path.")
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -119,13 +112,6 @@ if(XSMM_LIBRT)
   target_link_libraries(xsmm PUBLIC rt)
 endif()
 
-# The source-tree libxsmm_source.h uses ../src for header-only usage.  The
-# install-tree layout used by make install places the implementation files under
-# include/libxsmm instead, so generate the same relocatable header for CMake.
-file(READ "${XSMM_ROOT_DIR}/include/libxsmm_source.h" LIBXSMM_SOURCE_HEADER)
-string(REPLACE "\"../src/" "\"libxsmm/" LIBXSMM_SOURCE_HEADER "${LIBXSMM_SOURCE_HEADER}")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libxsmm_source.h" "${LIBXSMM_SOURCE_HEADER}")
-
 install(TARGETS xsmm
   EXPORT libxsmmTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -138,14 +124,6 @@ install(DIRECTORY ${XSMM_ROOT_DIR}/include/
     PATTERN "*.h"
     PATTERN "*.hpp"
     PATTERN "*.f")
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxsmm_source.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY ${XSMM_ROOT_DIR}/src/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxsmm
-  FILES_MATCHING
-    PATTERN "*.c"
-    PATTERN "*.h")
-
 install(EXPORT libxsmmTargets
   NAMESPACE libxsmm::
   FILE libxsmmTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,30 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-project(libxsmm C CXX)
 
-message(WARNING
-    "CMake is the not preferred tool to build libxsmm for the time being. It's only for some target usages and \"make\" is the tool of choice."
-)
+set(LIBXSMM_VERSION "1.17")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/version.txt")
+  file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/version.txt" LIBXSMM_VERSION_TXT LIMIT_COUNT 1)
+  string(REGEX MATCH "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" LIBXSMM_VERSION_MATCH "${LIBXSMM_VERSION_TXT}")
+  if(LIBXSMM_VERSION_MATCH)
+    set(LIBXSMM_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(LIBXSMM_VERSION_MINOR "${CMAKE_MATCH_2}")
+    if(CMAKE_MATCH_4)
+      set(LIBXSMM_VERSION_UPDATE "${CMAKE_MATCH_4}")
+    else()
+      set(LIBXSMM_VERSION_UPDATE "0")
+    endif()
+    set(LIBXSMM_VERSION "${LIBXSMM_VERSION_MAJOR}.${LIBXSMM_VERSION_MINOR}.${LIBXSMM_VERSION_UPDATE}")
+  endif()
+endif()
 
-option(XSMM_STATIC      "static build" ON)
+project(libxsmm VERSION ${LIBXSMM_VERSION} LANGUAGES C CXX)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+option(XSMM_STATIC "Build libxsmm as a static library" ON)
+option(XSMM_BLAS "Build libxsmm with external BLAS fallback support" OFF)
+set(LIBXSMM_INSTALL_PKGCONFIGDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE STRING
+  "Installation directory for pkg-config files")
 
 # display config
 message(STATUS "******** Build Summary ********")
@@ -15,6 +34,7 @@ message(STATUS "  CMake command         : ${CMAKE_COMMAND}")
 message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
 message(STATUS "Options:")
 message(STATUS "  XSMM_STATIC           : ${XSMM_STATIC}")
+message(STATUS "  XSMM_BLAS             : ${XSMM_BLAS}")
 
 # Platform
 set(LINUX False)
@@ -32,14 +52,11 @@ endif()
 # Setup current directory as project root directory.
 set(XSMM_ROOT_DIR ${PROJECT_SOURCE_DIR})
 
-set(CMAKE_INSTALL_MESSAGE NEVER)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
 file(GLOB XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${XSMM_ROOT_DIR}/include/libxsmm/*.c)
 list(REMOVE_ITEM XSMM_SRCS ${XSMM_ROOT_DIR}/include/libxsmm/libxsmm_generator_gemm_driver.c)
-
-
 
 if(NOT XSMM_SRCS)
   file(GLOB XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${XSMM_ROOT_DIR}/src/*.c)
@@ -53,14 +70,39 @@ if(XSMM_STATIC)
 else()
   add_library(xsmm SHARED ${XSMM_SRCS})
 endif()
+add_library(libxsmm::libxsmm ALIAS xsmm)
 
-target_include_directories(xsmm PUBLIC ${XSMM_INCLUDE_DIRS})
+set_target_properties(xsmm PROPERTIES
+  EXPORT_NAME libxsmm
+  OUTPUT_NAME xsmm)
+if(NOT XSMM_STATIC)
+  set_target_properties(xsmm PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR})
+endif()
 
-# https://github.com/libxsmm/libxsmm/tree/main#link-instructions
-# Please pass BLAS config by "-D__BLAS=0"
-# target_compile_definitions(xsmm PRIVATE __BLAS=0)
+target_include_directories(xsmm
+  PUBLIC
+    $<BUILD_INTERFACE:${XSMM_INCLUDE_DIRS}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-add_definitions(-DLIBXSMM_DEFAULT_CONFIG -U_DEBUG)
+target_compile_definitions(xsmm
+  PUBLIC
+    LIBXSMM_DEFAULT_CONFIG
+  PRIVATE
+    $<$<BOOL:${LINUX}>:LIBXSMM_BUILD=2>
+    $<$<NOT:$<BOOL:${LINUX}>>:LIBXSMM_BUILD=1>)
+
+if(NOT XSMM_BLAS)
+  target_compile_definitions(xsmm PRIVATE __BLAS=0)
+else()
+  find_package(BLAS REQUIRED)
+  target_link_libraries(xsmm PUBLIC ${BLAS_LIBRARIES})
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+  target_compile_options(xsmm PRIVATE -U_DEBUG)
+endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -76,3 +118,76 @@ check_library_exists(rt sched_yield "" XSMM_LIBRT)
 if(XSMM_LIBRT)
   target_link_libraries(xsmm PUBLIC rt)
 endif()
+
+# The source-tree libxsmm_source.h uses ../src for header-only usage.  The
+# install-tree layout used by make install places the implementation files under
+# include/libxsmm instead, so generate the same relocatable header for CMake.
+file(READ "${XSMM_ROOT_DIR}/include/libxsmm_source.h" LIBXSMM_SOURCE_HEADER)
+string(REPLACE "\"../src/" "\"libxsmm/" LIBXSMM_SOURCE_HEADER "${LIBXSMM_SOURCE_HEADER}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libxsmm_source.h" "${LIBXSMM_SOURCE_HEADER}")
+
+install(TARGETS xsmm
+  EXPORT libxsmmTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(DIRECTORY ${XSMM_ROOT_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.f")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxsmm_source.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${XSMM_ROOT_DIR}/src/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxsmm
+  FILES_MATCHING
+    PATTERN "*.c"
+    PATTERN "*.h")
+
+install(EXPORT libxsmmTargets
+  NAMESPACE libxsmm::
+  FILE libxsmmTargets.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxsmm)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/scripts/libxsmmConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libxsmmConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxsmm)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/libxsmmConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/libxsmmConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/libxsmmConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxsmm)
+
+set(LIBXSMM_PC_PRIVATE_LIBS "")
+if(CMAKE_THREAD_LIBS_INIT)
+  list(APPEND LIBXSMM_PC_PRIVATE_LIBS "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+if(CMAKE_DL_LIBS)
+  list(APPEND LIBXSMM_PC_PRIVATE_LIBS "-l${CMAKE_DL_LIBS}")
+endif()
+if(XSMM_LIBM)
+  list(APPEND LIBXSMM_PC_PRIVATE_LIBS "-lm")
+endif()
+if(XSMM_LIBRT)
+  list(APPEND LIBXSMM_PC_PRIVATE_LIBS "-lrt")
+endif()
+if(XSMM_BLAS)
+  list(APPEND LIBXSMM_PC_PRIVATE_LIBS "${BLAS_LIBRARIES}")
+endif()
+list(JOIN LIBXSMM_PC_PRIVATE_LIBS " " LIBXSMM_PC_PRIVATE_LIBS)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/scripts/libxsmm.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libxsmm.pc
+  @ONLY)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/libxsmm.pc
+  DESTINATION ${LIBXSMM_INSTALL_PKGCONFIGDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ add_library(libxsmm::libxsmm ALIAS xsmm)
 
 set_target_properties(xsmm PROPERTIES
   EXPORT_NAME libxsmm
-  OUTPUT_NAME xsmm)
+  OUTPUT_NAME xsmm
+  POSITION_INDEPENDENT_CODE ON)
 if(NOT XSMM_STATIC)
   set_target_properties(xsmm PROPERTIES
     VERSION ${PROJECT_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,30 @@ endif()
 
 set(XSMM_INCLUDE_DIRS ${XSMM_ROOT_DIR}/include)
 
+# Generate libxsmm_version.h
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(XSMM_GENERATED_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+file(MAKE_DIRECTORY ${XSMM_GENERATED_INCLUDE_DIR})
+
+execute_process(
+  COMMAND ${Python3_EXECUTABLE}
+          ${XSMM_ROOT_DIR}/scripts/libxsmm_config.py
+          ${XSMM_ROOT_DIR}/src/template/libxsmm_version.h
+  OUTPUT_FILE ${XSMM_GENERATED_INCLUDE_DIR}/libxsmm_version.h
+  RESULT_VARIABLE LIBXSMM_VERSION_HEADER_RC
+  WORKING_DIRECTORY ${XSMM_ROOT_DIR})
+
+if(NOT LIBXSMM_VERSION_HEADER_RC EQUAL 0)
+  message(FATAL_ERROR "Failed to generate libxsmm_version.h")
+endif()
+
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+  ${XSMM_ROOT_DIR}/version.txt
+  ${XSMM_ROOT_DIR}/scripts/libxsmm_config.py
+  ${XSMM_ROOT_DIR}/scripts/libxsmm_utilities.py
+  ${XSMM_ROOT_DIR}/src/template/libxsmm_version.h)
+
 if(XSMM_STATIC)
   add_library(xsmm STATIC ${XSMM_SRCS})
 else()
@@ -77,6 +101,7 @@ endif()
 target_include_directories(xsmm
   PUBLIC
     $<BUILD_INTERFACE:${XSMM_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${XSMM_GENERATED_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_definitions(xsmm
@@ -124,6 +149,8 @@ install(DIRECTORY ${XSMM_ROOT_DIR}/include/
     PATTERN "*.h"
     PATTERN "*.hpp"
     PATTERN "*.f")
+install(FILES ${XSMM_GENERATED_INCLUDE_DIR}/libxsmm_version.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT libxsmmTargets
   NAMESPACE libxsmm::
   FILE libxsmmTargets.cmake

--- a/scripts/libxsmm.pc.in
+++ b/scripts/libxsmm.pc.in
@@ -4,10 +4,10 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: libxsmm
-Description: Specialized tensor operations
+Description: @PROJECT_DESCRIPTION@
 URL: https://github.com/libxsmm/libxsmm/
 Version: @PROJECT_VERSION@
 
 Cflags: -I${includedir}
-Libs: @LIBXSMM_PC_LIBS@
-Libs.private: @LIBXSMM_PC_LIBS_PRIVATE@
+Libs: -L${libdir} -lxsmm
+Libs.private: @LIBXSMM_PC_PRIVATE_LIBS@

--- a/scripts/libxsmm.pc.in
+++ b/scripts/libxsmm.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: libxsmm
+Description: Specialized tensor operations
+URL: https://github.com/libxsmm/libxsmm/
+Version: @PROJECT_VERSION@
+
+Cflags: -I${includedir}
+Libs: @LIBXSMM_PC_LIBS@
+Libs.private: @LIBXSMM_PC_LIBS_PRIVATE@

--- a/scripts/libxsmmConfig.cmake.in
+++ b/scripts/libxsmmConfig.cmake.in
@@ -1,0 +1,18 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+set(LIBXSMM_VERSION "@PROJECT_VERSION@")
+set(LIBXSMM_STATIC "@XSMM_STATIC@")
+set(LIBXSMM_BLAS "@XSMM_BLAS@")
+
+find_dependency(Threads)
+if(LIBXSMM_BLAS)
+  find_dependency(BLAS)
+endif()
+
+set_and_check(LIBXSMM_TARGETS_FILE
+  "${CMAKE_CURRENT_LIST_DIR}/libxsmmTargets.cmake")
+include("${LIBXSMM_TARGETS_FILE}")
+
+check_required_components(libxsmm)

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-main-16372
+feature_8bit_amx_gemms_via_stack-1.17-3820

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_8bit_amx_gemms_via_stack-1.17-3820
+main-16372


### PR DESCRIPTION
* Add a standard CMake package configuration so downstream projects can use `find_package(libxsmm CONFIG REQUIRED)` and link against `libxsmm::libxsmm`.
* Export complete target usage requirements, including include directories, compile definitions, threading and system libraries.
* Remove the outdated CMake warning by adding explicit support for static/shared builds and optional BLAS fallback.
* Add optional BLAS fallback support through `XSMM_BLAS` and `find_package(BLAS)`.
* Install pkg-config files under `lib/pkgconfig` for both generic and static/shared-specific usage.
* Generate a relocatable install-tree version of `libxsmm_source.h` for header-only usage.
* Install the CMake package files under `lib/cmake/libxsmm` to make the package discoverable through `CMAKE_PREFIX_PATH`.
