### PR TITLE
Enable unittests for CMake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,75 @@
+name: LIBXSMM tests with CMake
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shared: [static, shared]
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install dependencies and tools
+      run: |
+        sudo apt update -y
+        sudo apt install -y gcc g++ gfortran libopenblas-openmp-dev ninja-build
+
+    - name: Configure
+      run: |
+        cmake -B build -GNinja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_INSTALL_PREFIX=$HOME/libxsmm-install \
+          -DBUILD_TESTING=ON \
+          -DBUILD_SHARED_LIBS=${{ matrix.shared == 'shared' && 'ON' || 'OFF' }}
+
+    - name: Build
+      run: cmake --build build -j $(nproc)
+
+    - name: Test
+      run: ctest --test-dir build --output-on-failure --parallel $(nproc)
+
+    - name: Install
+      run: cmake --install build
+
+    - name: Verify install
+      run: |
+        test -f $HOME/libxsmm-install/include/libxsmm.h
+        test -f $HOME/libxsmm-install/include/libxsmm_config.h
+        test -f $HOME/libxsmm-install/include/libxsmm_source.h
+        test -f $HOME/libxsmm-install/include/libxsmm_version.h
+        test -d $HOME/libxsmm-install/include/utils
+        ls $HOME/libxsmm-install/lib/libxsmm* >/dev/null
+        ls $HOME/libxsmm-install/lib/pkgconfig/libxsmm.pc >/dev/null
+        test -f $HOME/libxsmm-install/lib/cmake/libxsmm/libxsmmConfig.cmake
+        test -f $HOME/libxsmm-install/lib/cmake/libxsmm/libxsmmTargets.cmake
+
+    - name: Verify find_package
+      run: |
+        mkdir -p /tmp/test_find
+        cat > /tmp/test_find/CMakeLists.txt <<'EOF'
+        cmake_minimum_required(VERSION 3.13)
+        project(test_find C)
+        find_package(libxsmm CONFIG REQUIRED)
+        add_executable(test_find test_find.c)
+        target_link_libraries(test_find libxsmm::libxsmm)
+        EOF
+        cat > /tmp/test_find/test_find.c <<'EOF'
+        #include <libxsmm.h>
+        int main(void) { libxsmm_init(); libxsmm_finalize(); return 0; }
+        EOF
+        cmake -B /tmp/test_find/build -S /tmp/test_find \
+          -DCMAKE_PREFIX_PATH=$HOME/libxsmm-install
+        cmake --build /tmp/test_find/build
+        /tmp/test_find/build/test_find

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ message(WARNING
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-option(XSMM_BLAS "Build libxsmm with external BLAS fallback support" OFF)
 option(BUILD_SHARED_LIBS "Build libxsmm as a shared library" OFF)
 option(BUILD_TESTING "Build unittests" OFF)
 
@@ -29,7 +28,6 @@ message(STATUS "  CMake command         : ${CMAKE_COMMAND}")
 message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
 message(STATUS "Options:")
 message(STATUS "  BUILD_SHARED_LIBS     : ${BUILD_SHARED_LIBS}")
-message(STATUS "  XSMM_BLAS             : ${XSMM_BLAS}")
 
 # Platform
 set(LINUX False)
@@ -114,12 +112,8 @@ target_compile_definitions(xsmm
     $<$<BOOL:${LINUX}>:LIBXSMM_BUILD=2>
     $<$<NOT:$<BOOL:${LINUX}>>:LIBXSMM_BUILD=1>)
 
-if(NOT XSMM_BLAS)
-  target_compile_definitions(xsmm PRIVATE __BLAS=0)
-else()
-  find_package(BLAS REQUIRED)
-  target_link_libraries(xsmm PUBLIC ${BLAS_LIBRARIES})
-endif()
+# Keep the core library independent from classic BLAS wrappers/fallbacks.
+target_compile_definitions(xsmm PRIVATE __BLAS=0)
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   target_compile_options(xsmm PRIVATE -U_DEBUG)
@@ -191,9 +185,6 @@ if(XSMM_LIBM)
 endif()
 if(XSMM_LIBRT)
   list(APPEND LIBXSMM_PC_PRIVATE_LIBS "-lrt")
-endif()
-if(XSMM_BLAS)
-  list(APPEND LIBXSMM_PC_PRIVATE_LIBS "${BLAS_LIBRARIES}")
 endif()
 list(JOIN LIBXSMM_PC_PRIVATE_LIBS " " LIBXSMM_PC_PRIVATE_LIBS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,10 @@ message(WARNING
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-option(XSMM_STATIC "Build libxsmm as a static library" ON)
 option(XSMM_BLAS "Build libxsmm with external BLAS fallback support" OFF)
+option(BUILD_SHARED_LIBS "Build libxsmm as a shared library" OFF)
+option(BUILD_TESTING "Build unittests" OFF)
+
 set(LIBXSMM_INSTALL_PKGCONFIGDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE STRING
   "Installation directory for pkg-config files")
 
@@ -26,7 +28,7 @@ message(STATUS "  CMake version         : ${CMAKE_VERSION}")
 message(STATUS "  CMake command         : ${CMAKE_COMMAND}")
 message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
 message(STATUS "Options:")
-message(STATUS "  XSMM_STATIC           : ${XSMM_STATIC}")
+message(STATUS "  BUILD_SHARED_LIBS     : ${BUILD_SHARED_LIBS}")
 message(STATUS "  XSMM_BLAS             : ${XSMM_BLAS}")
 
 # Platform
@@ -82,10 +84,10 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
   ${XSMM_ROOT_DIR}/scripts/libxsmm_utilities.py
   ${XSMM_ROOT_DIR}/src/template/libxsmm_version.h)
 
-if(XSMM_STATIC)
-  add_library(xsmm STATIC ${XSMM_SRCS})
-else()
+if(BUILD_SHARED_LIBS)
   add_library(xsmm SHARED ${XSMM_SRCS})
+else()
+  add_library(xsmm STATIC ${XSMM_SRCS})
 endif()
 add_library(libxsmm::libxsmm ALIAS xsmm)
 
@@ -93,7 +95,7 @@ set_target_properties(xsmm PROPERTIES
   EXPORT_NAME libxsmm
   OUTPUT_NAME xsmm
   POSITION_INDEPENDENT_CODE ON)
-if(NOT XSMM_STATIC)
+if(BUILD_SHARED_LIBS)
   set_target_properties(xsmm PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR})
@@ -136,6 +138,11 @@ endif()
 check_library_exists(rt sched_yield "" XSMM_LIBRT)
 if(XSMM_LIBRT)
   target_link_libraries(xsmm PUBLIC rt)
+endif()
+
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
 endif()
 
 install(TARGETS xsmm

--- a/scripts/libxsmmConfig.cmake.in
+++ b/scripts/libxsmmConfig.cmake.in
@@ -3,14 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 set(LIBXSMM_VERSION "@PROJECT_VERSION@")
-set(LIBXSMM_STATIC "@XSMM_STATIC@")
-set(LIBXSMM_BLAS "@XSMM_BLAS@")
-
 find_dependency(Threads)
-if(LIBXSMM_BLAS)
-  find_dependency(BLAS)
-endif()
-
 set_and_check(LIBXSMM_TARGETS_FILE
   "${CMAKE_CURRENT_LIST_DIR}/libxsmmTargets.cmake")
 include("${LIBXSMM_TARGETS_FILE}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,313 @@
+# CMake-native test support mirroring the legacy tests/Makefile test entries.
+# Keep the build independent from the legacy Makefile path: CTest may reuse the
+# existing shell runners, but all executables are built by CMake.
+
+find_package(BLAS QUIET)
+find_package(OpenMP COMPONENTS C)
+
+set(LIBXSMM_CTEST_WITH_BLAS_SAMPLES "${BLAS_FOUND}" CACHE BOOL
+  "Build CTest sample programs which require external BLAS")
+if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES AND NOT BLAS_FOUND)
+  find_package(BLAS REQUIRED)
+endif()
+
+set(LIBXSMM_TEST_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(LIBXSMM_BINARY_ROOT "${PROJECT_BINARY_DIR}")
+set(LIBXSMM_SAMPLE_ROOT "${LIBXSMM_BINARY_ROOT}/samples")
+set(LIBXSMM_SCRIPT_ROOT "${LIBXSMM_BINARY_ROOT}/scripts")
+
+file(MAKE_DIRECTORY "${LIBXSMM_TEST_DIR}")
+file(MAKE_DIRECTORY "${LIBXSMM_SAMPLE_ROOT}")
+file(MAKE_DIRECTORY "${LIBXSMM_SCRIPT_ROOT}")
+
+file(COPY "${PROJECT_SOURCE_DIR}/tests/"
+  DESTINATION "${LIBXSMM_TEST_DIR}"
+  FILES_MATCHING
+    PATTERN "*.sh"
+    PATTERN "*.c"
+    PATTERN "*.h"
+    PATTERN "README.md")
+
+file(COPY "${PROJECT_SOURCE_DIR}/scripts/"
+  DESTINATION "${LIBXSMM_SCRIPT_ROOT}")
+
+foreach(sample_dir IN ITEMS
+    utilities/dispatch
+    utilities/memcmp
+    equation
+    eltwise
+    xgemm
+    xgemm_norm_packed
+    xgemm_sparse_Ainregs)
+  file(COPY "${PROJECT_SOURCE_DIR}/samples/${sample_dir}/"
+    DESTINATION "${LIBXSMM_SAMPLE_ROOT}/${sample_dir}")
+endforeach()
+
+function(libxsmm_set_runtime_output target rel_dir output_name)
+  set_target_properties(${target} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${LIBXSMM_BINARY_ROOT}/${rel_dir}"
+    RUNTIME_OUTPUT_NAME "${output_name}")
+endfunction()
+
+function(libxsmm_link_common target)
+  target_link_libraries(${target} PRIVATE libxsmm::libxsmm)
+  if(OpenMP_C_FOUND)
+    target_link_libraries(${target} PRIVATE OpenMP::OpenMP_C)
+  endif()
+endfunction()
+
+function(libxsmm_link_source_only target)
+  target_include_directories(${target} PRIVATE
+    "${PROJECT_SOURCE_DIR}/include"
+    "${XSMM_GENERATED_INCLUDE_DIR}")
+  target_compile_definitions(${target} PRIVATE
+    LIBXSMM_DEFAULT_CONFIG
+    LIBXSMM_BLAS_CONST
+    __BLAS=0)
+  target_link_libraries(${target} PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+  if(XSMM_LIBM)
+    target_link_libraries(${target} PRIVATE m)
+  endif()
+  if(XSMM_LIBRT)
+    target_link_libraries(${target} PRIVATE rt)
+  endif()
+  if(OpenMP_C_FOUND)
+    target_link_libraries(${target} PRIVATE OpenMP::OpenMP_C)
+  endif()
+endfunction()
+
+function(libxsmm_add_test_program name)
+  set(target "libxsmm_test_${name}")
+  if(name STREQUAL "headeronly")
+    add_executable(${target}
+      "${PROJECT_SOURCE_DIR}/tests/headeronly.c"
+      "${PROJECT_SOURCE_DIR}/tests/headeronly_aux.c")
+  else()
+    add_executable(${target} "${PROJECT_SOURCE_DIR}/tests/${name}.c")
+  endif()
+  target_include_directories(${target} PRIVATE
+    "${PROJECT_SOURCE_DIR}/tests"
+    "${PROJECT_SOURCE_DIR}/include"
+    "${XSMM_GENERATED_INCLUDE_DIR}")
+  target_compile_definitions(${target} PRIVATE LIBXSMM_BLAS_CONST)
+
+  if(name IN_LIST LIBXSMM_HEADER_ONLY_TESTS)
+    libxsmm_link_source_only(${target})
+  else()
+    libxsmm_link_common(${target})
+  endif()
+  libxsmm_set_runtime_output(${target} "tests" "${name}")
+endfunction()
+
+function(libxsmm_add_c_sample target rel_dir output_name source)
+  add_executable(${target} "${PROJECT_SOURCE_DIR}/${source}")
+  target_include_directories(${target} PRIVATE
+    "${PROJECT_SOURCE_DIR}/${rel_dir}"
+    "${PROJECT_SOURCE_DIR}/include"
+    "${XSMM_GENERATED_INCLUDE_DIR}")
+  libxsmm_link_common(${target})
+  libxsmm_set_runtime_output(${target} "${rel_dir}" "${output_name}")
+endfunction()
+
+function(libxsmm_add_blas_c_sample target rel_dir output_name source)
+  libxsmm_add_c_sample(${target} "${rel_dir}" "${output_name}" "${source}")
+  target_link_libraries(${target} PRIVATE ${BLAS_LIBRARIES})
+endfunction()
+
+set(LIBXSMM_HEADER_ONLY_TESTS
+  atomics
+  gemmflags
+  hash
+  headeronly
+  matdiff
+  memory)
+
+set(LIBXSMM_TEST_ENTRIES
+  atomics.c
+  gemmflags.c
+  hash.c
+  headeronly.c
+  malloc.c
+  matdiff.c
+  math.c
+  memory.c
+  registry.c
+  rng.c
+  threadsafety.c
+  timer.c
+  vla.c
+  dispatch.sh
+  eltwise.sh
+  equation.sh)
+if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES)
+  list(APPEND LIBXSMM_TEST_ENTRIES fsspmdm.sh)
+endif()
+list(APPEND LIBXSMM_TEST_ENTRIES
+  memcmp.sh
+  packed.sh
+  smm.sh)
+
+foreach(test_src IN ITEMS
+    atomics
+    gemmflags
+    hash
+    headeronly
+    malloc
+    matdiff
+    math
+    memory
+    registry
+    rng
+    threadsafety
+    timer
+    vla)
+  libxsmm_add_test_program(${test_src})
+endforeach()
+
+libxsmm_add_c_sample(libxsmm_sample_dispatch
+  "samples/utilities/dispatch" "dispatch"
+  "samples/utilities/dispatch/dispatch.c")
+libxsmm_add_c_sample(libxsmm_sample_memcmp
+  "samples/utilities/memcmp" "memcmp"
+  "samples/utilities/memcmp/memcmp.c")
+
+foreach(sample IN ITEMS
+    equation_simple
+    equation_gather_reduce
+    equation_relu
+    equation_simple_layernorm
+    equation_matmul
+    equation_softmax
+    equation_layernorm
+    equation_splitSGD
+    equation_bf16_x3_split_f32
+    equation_gather_dot
+    equation_gather_bcstmul_add)
+  libxsmm_add_c_sample("libxsmm_sample_${sample}"
+    "samples/equation" "${sample}"
+    "samples/equation/${sample}.c")
+endforeach()
+
+foreach(sample IN ITEMS
+    eltwise_unary_reduce
+    eltwise_unary_gather_scatter
+    eltwise_binary_simple
+    eltwise_ternary_simple
+    eltwise_unary_dropout
+    eltwise_unary_transform
+    eltwise_unary_simple
+    eltwise_unary_relu
+    eltwise_unary_quantization)
+  libxsmm_add_c_sample("libxsmm_sample_${sample}"
+    "samples/eltwise" "${sample}"
+    "samples/eltwise/${sample}.c")
+endforeach()
+
+foreach(sample IN ITEMS
+    gemm_kernel
+    gemm_kernel_fused
+    gemm_kernel_parallel)
+  libxsmm_add_c_sample("libxsmm_sample_${sample}"
+    "samples/xgemm" "${sample}"
+    "samples/xgemm/${sample}.c")
+endforeach()
+
+foreach(sample IN ITEMS asparse_packed_csr bsparse_packed_csr bsparse_packed_csc dense_packedacrm dense_packedbcrm)
+  libxsmm_add_c_sample("libxsmm_sample_${sample}_f64"
+    "samples/xgemm_norm_packed" "${sample}_f64"
+    "samples/xgemm_norm_packed/${sample}.c")
+  libxsmm_add_c_sample("libxsmm_sample_${sample}_f32"
+    "samples/xgemm_norm_packed" "${sample}_f32"
+    "samples/xgemm_norm_packed/${sample}.c")
+  target_compile_definitions("libxsmm_sample_${sample}_f32" PRIVATE __EDGE_EXECUTE_F32__)
+endforeach()
+
+libxsmm_add_c_sample(libxsmm_sample_gimmik
+  "samples/xgemm_sparse_Ainregs" "gimmik"
+  "samples/xgemm_sparse_Ainregs/gimmik.c")
+if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES)
+  libxsmm_add_blas_c_sample(libxsmm_sample_pyfr_driver_asp_reg
+    "samples/xgemm_sparse_Ainregs" "pyfr_driver_asp_reg"
+    "samples/xgemm_sparse_Ainregs/pyfr_driver_asp_reg.c")
+endif()
+
+add_custom_target(libxsmm_generate_eltwise_test_scripts ALL
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_simple_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_transform_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_reduce_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_relu_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_dropout_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_quant_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_gather_scatter_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_binary_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_ternary_test_scripts.sh
+  WORKING_DIRECTORY "${LIBXSMM_SAMPLE_ROOT}/eltwise/kernel_test"
+  COMMENT "Generating LIBXSMM eltwise test scripts")
+
+add_custom_target(libxsmm_generate_xgemm_test_scripts ALL
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_gemm_test_scripts.sh
+  COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_spmm_test_scripts.sh
+  WORKING_DIRECTORY "${LIBXSMM_SAMPLE_ROOT}/xgemm/kernel_test"
+  COMMENT "Generating LIBXSMM xgemm test scripts")
+
+foreach(target IN ITEMS
+    libxsmm_sample_eltwise_unary_reduce
+    libxsmm_sample_eltwise_unary_gather_scatter
+    libxsmm_sample_eltwise_binary_simple
+    libxsmm_sample_eltwise_ternary_simple
+    libxsmm_sample_eltwise_unary_dropout
+    libxsmm_sample_eltwise_unary_transform
+    libxsmm_sample_eltwise_unary_simple
+    libxsmm_sample_eltwise_unary_relu
+    libxsmm_sample_eltwise_unary_quantization)
+  add_dependencies(${target} libxsmm_generate_eltwise_test_scripts)
+endforeach()
+
+foreach(target IN ITEMS
+    libxsmm_sample_gemm_kernel
+    libxsmm_sample_gemm_kernel_fused
+    libxsmm_sample_gemm_kernel_parallel)
+  add_dependencies(${target} libxsmm_generate_xgemm_test_scripts)
+endforeach()
+
+function(libxsmm_require_test_files test_name)
+  set(files ${ARGN})
+  if(TEST "libxsmm-${test_name}")
+    set_tests_properties("libxsmm-${test_name}" PROPERTIES
+      REQUIRED_FILES "${files}")
+  endif()
+endfunction()
+
+foreach(test_entry IN LISTS LIBXSMM_TEST_ENTRIES)
+  get_filename_component(test_name "${test_entry}" NAME_WE)
+  add_test(NAME "libxsmm-${test_name}"
+    COMMAND "${LIBXSMM_TEST_DIR}/test.sh" "${test_entry}")
+  set_tests_properties("libxsmm-${test_name}" PROPERTIES
+    WORKING_DIRECTORY "${LIBXSMM_TEST_DIR}"
+    LABELS libxsmm)
+endforeach()
+
+# Avoid false positives from shell runners that may otherwise skip missing files.
+libxsmm_require_test_files(dispatch
+  "${LIBXSMM_SAMPLE_ROOT}/utilities/dispatch/dispatch")
+libxsmm_require_test_files(memcmp
+  "${LIBXSMM_SAMPLE_ROOT}/utilities/memcmp/memcmp")
+libxsmm_require_test_files(equation
+  "${LIBXSMM_SAMPLE_ROOT}/equation/equation_simple"
+  "${LIBXSMM_SAMPLE_ROOT}/equation/equation_matmul"
+  "${LIBXSMM_SAMPLE_ROOT}/equation/equation_test/equation_simple.sh")
+libxsmm_require_test_files(eltwise
+  "${LIBXSMM_SAMPLE_ROOT}/eltwise/eltwise_unary_simple"
+  "${LIBXSMM_SAMPLE_ROOT}/eltwise/eltwise_binary_simple")
+libxsmm_require_test_files(smm
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm/gemm_kernel"
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm/gemm_kernel_fused")
+libxsmm_require_test_files(packed
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedacrm_f32"
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedacrm_f64"
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedbcrm_f32"
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedbcrm_f64")
+if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES)
+  libxsmm_require_test_files(fsspmdm
+    "${LIBXSMM_SAMPLE_ROOT}/xgemm_sparse_Ainregs/pyfr_driver_asp_reg")
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-# CMake-native test support mirroring the legacy tests/Makefile test entries.
-# Keep the build independent from the legacy Makefile path: CTest may reuse the
+# CMake-native test support mirroring the GNU Makefile test entries.
+# Keep the build independent from the GNU Makefile path: CTest may reuse the
 # existing shell runners, but all executables are built by CMake.
 
 find_package(BLAS QUIET)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,12 +2,11 @@
 # Keep the build independent from the GNU Makefile path: CTest may reuse the
 # existing shell runners, but all executables are built by CMake.
 
-find_package(BLAS QUIET)
 find_package(OpenMP COMPONENTS C)
 
-set(LIBXSMM_CTEST_WITH_BLAS_SAMPLES "${BLAS_FOUND}" CACHE BOOL
-  "Build CTest sample programs which require external BLAS")
-if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES AND NOT BLAS_FOUND)
+option(LIBXSMM_CTEST_WITH_BLAS_REFERENCE
+  "Build selected sample tests with an external BLAS reference path" OFF)
+if(LIBXSMM_CTEST_WITH_BLAS_REFERENCE)
   find_package(BLAS REQUIRED)
 endif()
 
@@ -109,9 +108,14 @@ function(libxsmm_add_c_sample target rel_dir output_name source)
   libxsmm_set_runtime_output(${target} "${rel_dir}" "${output_name}")
 endfunction()
 
-function(libxsmm_add_blas_c_sample target rel_dir output_name source)
+function(libxsmm_add_fsspmdm_sample target rel_dir output_name source)
   libxsmm_add_c_sample(${target} "${rel_dir}" "${output_name}" "${source}")
-  target_link_libraries(${target} PRIVATE ${BLAS_LIBRARIES})
+  if(LIBXSMM_CTEST_WITH_BLAS_REFERENCE)
+    target_compile_definitions(${target} PRIVATE __USE_BLAS=1)
+    target_link_libraries(${target} PRIVATE ${BLAS_LIBRARIES})
+  else()
+    target_compile_definitions(${target} PRIVATE __USE_BLAS=0)
+  endif()
 endfunction()
 
 set(LIBXSMM_HEADER_ONLY_TESTS
@@ -139,10 +143,8 @@ set(LIBXSMM_TEST_ENTRIES
   dispatch.sh
   eltwise.sh
   equation.sh)
-if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES)
-  list(APPEND LIBXSMM_TEST_ENTRIES fsspmdm.sh)
-endif()
 list(APPEND LIBXSMM_TEST_ENTRIES
+  fsspmdm.sh
   memcmp.sh
   packed.sh
   smm.sh)
@@ -225,11 +227,9 @@ endforeach()
 libxsmm_add_c_sample(libxsmm_sample_gimmik
   "samples/xgemm_sparse_Ainregs" "gimmik"
   "samples/xgemm_sparse_Ainregs/gimmik.c")
-if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES)
-  libxsmm_add_blas_c_sample(libxsmm_sample_pyfr_driver_asp_reg
-    "samples/xgemm_sparse_Ainregs" "pyfr_driver_asp_reg"
-    "samples/xgemm_sparse_Ainregs/pyfr_driver_asp_reg.c")
-endif()
+libxsmm_add_fsspmdm_sample(libxsmm_sample_pyfr_driver_asp_reg
+  "samples/xgemm_sparse_Ainregs" "pyfr_driver_asp_reg"
+  "samples/xgemm_sparse_Ainregs/pyfr_driver_asp_reg.c")
 
 add_custom_target(libxsmm_generate_eltwise_test_scripts ALL
   COMMAND "${CMAKE_COMMAND}" -E env bash ./generate_unary_simple_test_scripts.sh
@@ -307,7 +307,5 @@ libxsmm_require_test_files(packed
   "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedacrm_f64"
   "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedbcrm_f32"
   "${LIBXSMM_SAMPLE_ROOT}/xgemm_norm_packed/dense_packedbcrm_f64")
-if(LIBXSMM_CTEST_WITH_BLAS_SAMPLES)
-  libxsmm_require_test_files(fsspmdm
-    "${LIBXSMM_SAMPLE_ROOT}/xgemm_sparse_Ainregs/pyfr_driver_asp_reg")
-endif()
+libxsmm_require_test_files(fsspmdm
+  "${LIBXSMM_SAMPLE_ROOT}/xgemm_sparse_Ainregs/pyfr_driver_asp_reg")


### PR DESCRIPTION
This PR enables the existing LIBXSMM tests through CMake/CTest.

The implementation is CMake-native: it builds the required test and sample executables directly and registers the default `tests/test.sh` entries as separate CTest tests, without invoking the legacy Makefile test target.

BLAS-dependent sample tests are kept optional and are enabled only when BLAS is available.

One additional modification: Use CMake-general `BUILD_SHARED_LIBS` option name instead of specific `XSMM_STATIC` to decide whether to build static or shared library.