### PR TITLE
Potential fix for code scanning alert no. 458: Unsigned difference expression compared to zero

### DIFF
--- a/src/generator_common_aarch64.c
+++ b/src/generator_common_aarch64.c
@@ -623,7 +623,7 @@ void libxsmm_generator_load_2dregblock_aarch64_asimd( libxsmm_generated_code* io
                                                 l_vec_reg_acc_start + l_m_blocks[0] + (l_m_total_blocks * l_n),
                                                 LIBXSMM_AARCH64_ASIMD_WIDTH_S );
       }
-      if ( i_ld-l_m_bytes > 0 ) {
+      if ( i_ld > l_m_bytes ) {
         libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                        i_gp_reg_addr, i_gp_reg_scratch, i_gp_reg_addr,
                                                        ((long long)i_ld - l_m_bytes) );

--- a/src/generator_gemm_common_aarch64.c
+++ b/src/generator_gemm_common_aarch64.c
@@ -1002,7 +1002,7 @@ void libxsmm_generator_gemm_load_add_colbias_2dregblock_aarch64_asimd(  libxsmm_
                                                    l_vec_reg_acc_start + l_m_blocks[0] + (l_m_total_blocks * l_n),
                                                    LIBXSMM_AARCH64_ASIMD_TUPLETYPE_4S );
       }
-      if ( i_ld-l_m_bytes > 0 ) {
+      if ( i_ld > l_m_bytes ) {
         libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                        i_gp_reg_addr, i_gp_reg_scratch0, i_gp_reg_addr,
                                                        ((long long)i_ld - l_m_bytes) );


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/458](https://github.com/libxsmm/libxsmm/security/code-scanning/458)

Use a direct comparison that avoids subtraction in the condition:

- Replace `if ( i_ld-l_m_bytes > 0 )` with `if ( i_ld > l_m_bytes )`.
- Keep the existing immediate computation unchanged, since inside that guarded block `i_ld - l_m_bytes` is guaranteed non-negative and safe.
- No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
