### PR TITLE
Potential fix for code scanning alert no. 456,457,458: Unsigned difference expression compared to zero

### DIFF
--- a/src/generator_common_aarch64.c
+++ b/src/generator_common_aarch64.c
@@ -1512,7 +1512,7 @@ void libxsmm_generator_store_2dregblock_aarch64_asimd( libxsmm_generated_code* i
                                                 LIBXSMM_AARCH64_ASIMD_WIDTH_S );
     }
 
-    if ( i_ld-l_m_bytes > 0 ) {
+    if ( i_ld > l_m_bytes ) {
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                      i_gp_reg_addr, i_gp_reg_scratch, i_gp_reg_addr,
                                                      ((long long)i_ld - l_m_bytes) );

--- a/src/generator_common_aarch64.c
+++ b/src/generator_common_aarch64.c
@@ -623,7 +623,7 @@ void libxsmm_generator_load_2dregblock_aarch64_asimd( libxsmm_generated_code* io
                                                 l_vec_reg_acc_start + l_m_blocks[0] + (l_m_total_blocks * l_n),
                                                 LIBXSMM_AARCH64_ASIMD_WIDTH_S );
       }
-      if ( i_ld-l_m_bytes > 0 ) {
+      if ( i_ld > l_m_bytes ) {
         libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                        i_gp_reg_addr, i_gp_reg_scratch, i_gp_reg_addr,
                                                        ((long long)i_ld - l_m_bytes) );

--- a/src/generator_gemm_common_aarch64.c
+++ b/src/generator_gemm_common_aarch64.c
@@ -1002,7 +1002,7 @@ void libxsmm_generator_gemm_load_add_colbias_2dregblock_aarch64_asimd(  libxsmm_
                                                    l_vec_reg_acc_start + l_m_blocks[0] + (l_m_total_blocks * l_n),
                                                    LIBXSMM_AARCH64_ASIMD_TUPLETYPE_4S );
       }
-      if ( i_ld-l_m_bytes > 0 ) {
+      if ( i_ld > l_m_bytes ) {
         libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                        i_gp_reg_addr, i_gp_reg_scratch0, i_gp_reg_addr,
                                                        ((long long)i_ld - l_m_bytes) );

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-feature_refactor_datatypes-1.17-3825
+alert-autofix-456-3


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/456](https://github.com/libxsmm/libxsmm/security/code-scanning/456)

The safest fix is to avoid subtracting before checking ordering. Replace:

- `if ( i_ld-l_m_bytes > 0 ) { ... ((long long)i_ld - l_m_bytes) ... }`

with an order check first:

- `if ( i_ld > l_m_bytes ) { ... ((long long)i_ld - l_m_bytes) ... }`

This preserves existing functionality when `i_ld >= l_m_bytes`, while preventing unsigned underflow in the condition.  
In `src/generator_common_aarch64.c`, update the `if` statement around line 1515 only. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
