### PR TITLE
Potential fix for code scanning alert no. 430: Redundant null check due to previous dereference

### DIFF
--- a/src/generator_common.c
+++ b/src/generator_common.c
@@ -78,9 +78,7 @@ void libxsmm_append_code_as_string( libxsmm_generated_code* io_generated_code,
 
   /* append new string */
   /* TODO: using memcpy instead? */
-  if (i_code_to_append != NULL) {
-    strcat(l_new_string, i_code_to_append);
-  }
+  strcat(l_new_string, i_code_to_append);
 
   /* free old memory and overwrite pointer */
   if (l_length_1 > 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/430](https://github.com/libxsmm/libxsmm/security/code-scanning/430)

In general, fix this by ensuring null checks happen before any dereference and avoid re-checking the same pointer once control flow already guarantees non-null.

For this snippet in `src/generator_common.c`, the best no-functional-change fix is:
- Keep the existing early validation at lines 57–62 (which rejects NULL/empty input and returns).
- Remove the redundant `if (i_code_to_append != NULL)` at lines 81–83.
- Call `strcat(l_new_string, i_code_to_append);` directly, since reaching this point guarantees `i_code_to_append` is non-null and non-empty.

No new methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
