### PR TITLE
Potential fix for code scanning alert no. 477: Multiplication result converted to larger type

### DIFF
--- a/src/generator_gemm_sme.c
+++ b/src/generator_gemm_sme.c
@@ -1772,7 +1772,7 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                     l_gp_reg_mapping.gp_reg_b,
                                                     l_gp_reg_mapping.gp_reg_help_0,
                                                     l_gp_reg_mapping.gp_reg_b ,
-                                                    (l_xgemm_desc_opa->k - l_trans_rest) * l_micro_kernel_config.datatype_size_in );
+                                                    ((unsigned long long)(l_xgemm_desc_opa->k - l_trans_rest)) * l_micro_kernel_config.datatype_size_in );
     }
     l_perfect_blocking_m = 16;
     l_perfect_m_count = l_xgemm_desc_opa->m / 16;


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/477](https://github.com/libxsmm/libxsmm/security/code-scanning/477)

Promote one multiplicand to 64-bit **before** multiplication so arithmetic is carried out in 64-bit, avoiding intermediate overflow.

Best minimal fix (no behavior change for valid ranges): in `src/generator_gemm_sme.c`, at the call around line 1775, cast `(l_xgemm_desc_opa->k - l_trans_rest)` (or the other factor) to `unsigned long long` in the product expression.

No new includes, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
