### PR TITLE
Potential fix for code scanning alert no. 469: Multiplication result converted to larger type

### DIFF
--- a/src/generator_gemm_sme.c
+++ b/src/generator_gemm_sme.c
@@ -449,7 +449,7 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                     l_gp_reg_mapping.gp_reg_b,
                                                     l_gp_reg_mapping.gp_reg_help_0,
                                                     l_gp_reg_mapping.gp_reg_b ,
-                                                    (l_xgemm_desc_opa->k - l_trans_rest) * l_micro_kernel_config.datatype_size_in );
+                                                    ((unsigned long long)(l_xgemm_desc_opa->k - l_trans_rest)) * (unsigned long long)l_micro_kernel_config.datatype_size_in );
     } else {
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                     LIBXSMM_AARCH64_INSTR_GP_META_ADD,


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/469](https://github.com/libxsmm/libxsmm/security/code-scanning/469)

To fix this safely without changing behavior, force the multiplication to be carried out in a 64-bit type by casting one operand before multiplication.

Best fix in `src/generator_gemm_sme.c` at the expression used as the immediate on line 452:
- Change  
  `(l_xgemm_desc_opa->k - l_trans_rest) * l_micro_kernel_config.datatype_size_in`
- To  
  `((unsigned long long)(l_xgemm_desc_opa->k - l_trans_rest)) * (unsigned long long)l_micro_kernel_config.datatype_size_in`

This ensures no intermediate 32-bit overflow occurs and keeps semantics the same for in-range values, while making large values correct.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
