### PR TITLE
Potential fix for code scanning alert no. 526: Multiplication result converted to larger type

### DIFF
--- a/src/generator_gemm_amx.c
+++ b/src/generator_gemm_amx.c
@@ -1430,7 +1430,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_convert_KxM_bf8_to_vnni4( libxsmm
               LIBXSMM_X86_INSTR_PREFETCHT0,
               i_gp_reg,
               LIBXSMM_X86_GP_REG_UNDEF, 0,
-              (int)((long long)ik * i_ldi + i_ldi * 4 * uk + (im/4) * 64 + (long long)i_xgemm_desc->c1) );
+              (int)((long long)ik * i_ldi + (long long)i_ldi * 4 * uk + (im/4) * 64 + (long long)i_xgemm_desc->c1) );
         }
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/526](https://github.com/libxsmm/libxsmm/security/code-scanning/526)

To fix this without changing intended functionality, ensure the potentially large multiplicative term is computed in 64-bit type **before** multiplication. The best minimal fix is to cast one operand in the `i_ldi * 4 * uk` chain to `long long` inside the prefetch offset expression.

In `src/generator_gemm_amx.c`, at the `libxsmm_x86_instruction_prefetch` call around line 1433, change:
- `i_ldi * 4 * uk`
to
- `(long long)i_ldi * 4 * uk`

This forces the full chained multiplication into 64-bit arithmetic, preventing overflow in `unsigned int` intermediates while preserving the final `(int)` cast behavior already present in the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
