### PR TITLE
Potential fix for code scanning alert no. 429: Multiplication result converted to larger type

### DIFF
--- a/src/generator_mateltwise_reduce_aarch64.c
+++ b/src/generator_mateltwise_reduce_aarch64.c
@@ -1701,7 +1701,7 @@ void libxsmm_generator_reduce_cols_index_aarch64_microkernel( libxsmm_generated_
     }
 
     if (load_acc == 1) {
-      long long l_adj_offset = m_unroll_factor * vlen * i_micro_kernel_config->datatype_size_out;
+      long long l_adj_offset = (long long)m_unroll_factor * vlen * i_micro_kernel_config->datatype_size_out;
       if (l_is_peeled_loop) {
         l_adj_offset = (long long)peeled_m_trips * i_micro_kernel_config->datatype_size_out * vlen - (long long)use_m_masking * ((long long)vlen - mask_count) * i_micro_kernel_config->datatype_size_out;
       }


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/429](https://github.com/libxsmm/libxsmm/security/code-scanning/429)

Promote the multiplication to `long long` **before** any multiply happens.  
Best fix: cast the first multiplicand in line 1704 to `long long`, so the whole chain is evaluated in 64-bit arithmetic.

Edit in `src/generator_mateltwise_reduce_aarch64.c` around line 1704:
- Change:
  - `long long l_adj_offset = m_unroll_factor * vlen * i_micro_kernel_config->datatype_size_out;`
- To:
  - `long long l_adj_offset = (long long)m_unroll_factor * vlen * i_micro_kernel_config->datatype_size_out;`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
