### PR TITLE
Potential fix for code scanning alert no. 416: Multiplication result converted to larger type

### DIFF
--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -1003,7 +1003,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_mmla_sve( libxsm
                                                    i_gp_reg_mapping->gp_reg_c,
                                                    l_gp_reg_scratch,
                                                    i_gp_reg_mapping->gp_reg_c,
-                                                   (long long)i_packed_width * 2 * l_n_advancements * i_micro_kernel_config->datatype_size_out );
+                                                   ((unsigned long long)i_packed_width * 2 * l_n_advancements) * i_micro_kernel_config->datatype_size_out );
     if (l_n_blocks > 1) {
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                      LIBXSMM_AARCH64_INSTR_GP_META_ADD,

--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -1003,7 +1003,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_mmla_sve( libxsm
                                                    i_gp_reg_mapping->gp_reg_c,
                                                    l_gp_reg_scratch,
                                                    i_gp_reg_mapping->gp_reg_c,
-                                                   (i_packed_width * 2 * l_n_advancements) * i_micro_kernel_config->datatype_size_out );
+                                                   (long long)i_packed_width * 2 * l_n_advancements * i_micro_kernel_config->datatype_size_out );
     if (l_n_blocks > 1) {
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                      LIBXSMM_AARCH64_INSTR_GP_META_ADD,


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/416](https://github.com/libxsmm/libxsmm/security/code-scanning/416)

To fix this safely without changing behavior, ensure the multiplication at line 1006 is carried out in 64-bit arithmetic from the first factor, by casting one leading operand to `long long` (or another appropriate 64-bit integer type used in this file). This prevents intermediate overflow in `unsigned int` math.

Best single change:
- In `src/generator_packed_spgemm_bcsc_bsparse_aarch64.c`, at the `libxsmm_aarch64_instruction_alu_compute_imm64` call around line 1006, replace:
  - `(i_packed_width * 2 * l_n_advancements) * i_micro_kernel_config->datatype_size_out`
  with:
  - `(long long)i_packed_width * 2 * l_n_advancements * i_micro_kernel_config->datatype_size_out`

This is consistent with nearby code style (line 1013/1024 already uses `(long long)i_packed_width * ...`) and avoids introducing new includes or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
