### PR TITLE
Potential fix for code scanning alert no. 409: Multiplication result converted to larger type

### DIFF
--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -795,7 +795,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_mmla_sve( libxsm
                                                          i_gp_reg_mapping->gp_reg_c,
                                                          l_gp_reg_scratch,
                                                          i_gp_reg_mapping->gp_reg_c,
-                                                         ((long long)i_packed_width * 2 - i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
+                                                         ((long long)i_packed_width * 2 - (long long)i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
         }
       }
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,

--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -789,7 +789,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_mmla_sve( libxsm
                                                          i_gp_reg_mapping->gp_reg_c,
                                                          ((long long)i_packed_width - i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
         }
-        if ((i_packed_width * 2 - i_packed_blocking * i_simd_packed_width) > 0) {
+        if (((long long)i_packed_width * 2 - (long long)i_packed_blocking * i_simd_packed_width) > 0) {
           libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                          LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                          i_gp_reg_mapping->gp_reg_c,


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/409](https://github.com/libxsmm/libxsmm/security/code-scanning/409)

To fix this safely without changing behavior, ensure the multiplication is performed in a wide integer type by casting one operand of `i_packed_blocking * i_simd_packed_width` to `long long` before the multiply.

Best minimal change in `src/generator_packed_spgemm_bcsc_bsparse_aarch64.c`:
- In the `if ((i_packed_width * 2 - i_packed_blocking * i_simd_packed_width) > 0)` block, update line 798 expression to:
  - `((long long)i_packed_width * 2 - (long long)i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out`
This keeps the same logic/sign behavior but prevents intermediate overflow in the flagged product.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
