### PR TITLE
Potential fix for code scanning alert no. 415: Multiplication result converted to larger type

### DIFF
--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -989,7 +989,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_mmla_sve( libxsm
                                                        i_gp_reg_mapping->gp_reg_c,
                                                        ((long long)i_packed_width - i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
       }
-      if ((i_packed_width * 2 - i_packed_blocking * i_simd_packed_width) > 0) {
+      if (((long long)i_packed_width * 2 - (long long)i_packed_blocking * i_simd_packed_width) > 0) {
         libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                        LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                        i_gp_reg_mapping->gp_reg_c,

--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -995,7 +995,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_mmla_sve( libxsm
                                                        i_gp_reg_mapping->gp_reg_c,
                                                        l_gp_reg_scratch,
                                                        i_gp_reg_mapping->gp_reg_c,
-                                                       ((long long)i_packed_width * 2 - i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
+                                                       ((long long)i_packed_width * 2 - (long long)i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
       }
     }
     libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/415](https://github.com/libxsmm/libxsmm/security/code-scanning/415)

Promote at least one operand of `i_packed_blocking * i_simd_packed_width` to `long long` **before** multiplication so the multiplication is performed in 64-bit arithmetic.

Best minimal fix (no behavior change except preventing overflow): in `src/generator_packed_spgemm_bcsc_bsparse_aarch64.c`, update line 998 expression from:

- `((long long)i_packed_width * 2 - i_packed_blocking * i_simd_packed_width) * ...`

to:

- `((long long)i_packed_width * 2 - (long long)i_packed_blocking * i_simd_packed_width) * ...`

No new includes, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
