### PR TITLE
Potential fix for code scanning alert no. 406: Multiplication result converted to larger type

### DIFF
--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -1347,7 +1347,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_bfdot_sve(libxsm
                                                        i_gp_reg_mapping->gp_reg_c,
                                                        l_gp_reg_scratch,
                                                        i_gp_reg_mapping->gp_reg_c,
-                                                       ((long long)i_packed_width - i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
+                                                       ((long long)i_packed_width - (long long)i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
       }
     }
     libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/406](https://github.com/libxsmm/libxsmm/security/code-scanning/406)

The fix is to ensure multiplication is carried out in a wider type by casting one operand **before** the `*`.  
For this specific line in `src/generator_packed_spgemm_bcsc_bsparse_aarch64.c` (around line 1350), change:

- from: `((long long)i_packed_width - i_packed_blocking * i_simd_packed_width) * ...`
- to: `((long long)i_packed_width - (long long)i_packed_blocking * i_simd_packed_width) * ...`

This preserves behavior while preventing intermediate overflow in the product. No new methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
