### PR TITLE
Potential fix for code scanning alert no. 404: Multiplication result converted to larger type

### DIFF
--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -1257,7 +1257,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_bfdot_sve(libxsm
                                                        l_tmp_a_gp_reg,
                                                        l_gp_reg_scratch,
                                                        l_tmp_a_gp_reg,
-                                                       ((long long)i_packed_width * l_vnni_block_size - l_a_adjustments * i_simd_packed_width * l_vnni_block_size ) * i_micro_kernel_config->datatype_size_in );
+                                                       ((long long)i_packed_width * l_vnni_block_size - (long long)l_a_adjustments * i_simd_packed_width * l_vnni_block_size ) * i_micro_kernel_config->datatype_size_in );
       }
 
       /* loop over the columns of B/C */


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/404](https://github.com/libxsmm/libxsmm/security/code-scanning/404)

To fix this safely without changing behavior, force the multiplication chain in the highlighted term to be computed in `long long` from the first factor.  
Best fix: cast `l_a_adjustments` to `long long` in the second product on line 1260 (or cast one of the first multiplicands), so overflow cannot occur in 32-bit arithmetic before subtraction.

Change needed in:
- `src/generator_packed_spgemm_bcsc_bsparse_aarch64.c`
- Region around line 1260, inside the `libxsmm_aarch64_instruction_alu_compute_imm64` call.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
