### PR TITLE
Potential fix for code scanning alert no. 400: Multiplication result converted to larger type

### DIFF
--- a/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
+++ b/src/generator_packed_spgemm_bcsc_bsparse_aarch64.c
@@ -1189,7 +1189,7 @@ void libxsmm_generator_packed_spgemm_bcsc_bsparse_aarch64_kloop_bfdot_sve(libxsm
                                                          i_gp_reg_mapping->gp_reg_c,
                                                          l_gp_reg_scratch,
                                                          i_gp_reg_mapping->gp_reg_c,
-                                                         ((long long)i_packed_width - i_packed_blocking * i_simd_packed_width) * i_micro_kernel_config->datatype_size_out );
+                                                         ((long long)i_packed_width - ((long long)i_packed_blocking * i_simd_packed_width)) * i_micro_kernel_config->datatype_size_out );
         }
       }
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,


### PR DESCRIPTION
Potential fix for [https://github.com/libxsmm/libxsmm/security/code-scanning/400](https://github.com/libxsmm/libxsmm/security/code-scanning/400)

To fix this class of issue, ensure at least one operand is cast to a larger integer type **before** multiplication, so the multiplication itself is performed in that larger type.

Best fix here: in `src/generator_packed_spgemm_bcsc_bsparse_aarch64.c`, at the expression used as the immediate offset on line 1192, cast one multiplicand to `long long` before multiplying:
- from: `((long long)i_packed_width - i_packed_blocking * i_simd_packed_width) * ...`
- to: `((long long)i_packed_width - ((long long)i_packed_blocking * i_simd_packed_width)) * ...`

This preserves behavior for valid ranges while removing overflow risk in intermediate arithmetic. No new imports, helper methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
