### PR TITLE
CMake: support Fortran-only package consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
-set(LIBXSMM_VERSION "1.17")
+set(LIBXSMM_VERSION "1.17.0")
 
 project(libxsmm
   VERSION ${LIBXSMM_VERSION}
@@ -203,7 +203,34 @@ endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-target_link_libraries(xsmm PUBLIC Threads::Threads)
+
+# Do not expose Threads::Threads in the installed export. FindThreads requires
+# C or CXX to be enabled, which prevents a Fortran-only consumer from loading
+# the package configuration. Propagate the resolved usage requirements instead.
+function(libxsmm_propagate_usage_requirements target dependency)
+  foreach(property IN ITEMS
+      INTERFACE_LINK_LIBRARIES
+      INTERFACE_LINK_OPTIONS
+      INTERFACE_COMPILE_OPTIONS
+      INTERFACE_COMPILE_DEFINITIONS)
+    get_target_property(requirements ${dependency} ${property})
+    if(requirements MATCHES "-NOTFOUND$")
+      continue()
+    endif()
+
+    if(property STREQUAL "INTERFACE_LINK_LIBRARIES")
+      target_link_libraries(${target} PUBLIC ${requirements})
+    elseif(property STREQUAL "INTERFACE_LINK_OPTIONS")
+      target_link_options(${target} PUBLIC ${requirements})
+    elseif(property STREQUAL "INTERFACE_COMPILE_OPTIONS")
+      target_compile_options(${target} PUBLIC ${requirements})
+    else()
+      target_compile_definitions(${target} PUBLIC ${requirements})
+    endif()
+  endforeach()
+endfunction()
+
+libxsmm_propagate_usage_requirements(xsmm Threads::Threads)
 target_link_libraries(xsmm PUBLIC ${CMAKE_DL_LIBS})
 
 include(CheckLibraryExists)

--- a/Makefile
+++ b/Makefile
@@ -1323,6 +1323,7 @@ endif
 
 $(PCMKDIR)/libxsmmConfig.cmake: $(ROOTSCR)/libxsmmConfig.cmake $(ROOTSCR)/libxsmmConfigVersion.cmake.in $(PCMKDIR)/.make
 	@$(SED) -e 's|@VERSION@|$(VERSION_STRING)|g' \
+		-e 's|@THREADS@|$(THREADS)|g' \
 		"$(ROOTSCR)/libxsmmConfig.cmake" > "$@"
 	@$(SED) -e 's|@VERSION@|$(VERSION_STRING)|g' \
 		"$(ROOTSCR)/libxsmmConfigVersion.cmake.in" > "$(PCMKDIR)/libxsmmConfigVersion.cmake"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ The main interface file is *generated*, and it is therefore **not** stored in th
 
 ### Classic Library (ABI)
 
-There are two ways to rely on prebuilt code for a given project: <span>(1)&#160;using</span> LIBXSMM's Makefile based build system, <span>(2)&#160;or</span> using another build system and writing own [rules for building LIBXSMM](#rules-for-building-libxsmm). The Makefile based build system relies on <span>GNU&#160;Make</span> (typically associated with the `make` command, but e.g. FreeBSD is calling it `gmake`). The build can be customized by using <span>key&#8209;value</span> pairs. <span>Key&#8209;value</span> pairs can be supplied in two ways: <span>(1)&#160;after</span> the "make" command, or <span>(2)&#160;prior</span> to the "make" command (`env`) which is effectively the same as exporting the <span>key&#8209;value</span> pair as an environment variable (`export`, or `setenv`). Both methods can be mixed (the second method may require make's `-e` flag).
+LIBXSMM provides native GNU Make and CMake build systems for the classic library ABI. GNU Make remains the reference build path and exposes the full set of build-time customization options and legacy sample targets. CMake supports the core library, optional Fortran module interface, generator executables, installation, and CMake package integration. Projects using another build system can also write their own [rules for building LIBXSMM](#rules-for-building-libxsmm).
+
+The Makefile based build system relies on <span>GNU&#160;Make</span> (typically associated with the `make` command, but e.g. FreeBSD is calling it `gmake`). The build can be customized by using <span>key&#8209;value</span> pairs. <span>Key&#8209;value</span> pairs can be supplied in two ways: <span>(1)&#160;after</span> the "make" command, or <span>(2)&#160;prior</span> to the "make" command (`env`) which is effectively the same as exporting the <span>key&#8209;value</span> pair as an environment variable (`export`, or `setenv`). Both methods can be mixed (the second method may require make's `-e` flag).
 
 <a name="zero-config-abi"></a>In contrast to [header-only](#zero-config) which does not require configuration by default, 3rd-party build systems can compile and link LIBXSMM's sources but still avoid configuring the library (per `libxsmm_config.py`). The prerequisite to omit configuration is to opt-in by defining LIBXSMM_DEFAULT_CONFIG (`-D`). The zero-config feature is not available for LIBXSMM's Fortran interface.
 
@@ -159,6 +161,35 @@ make realclean
 
 Using the Fortran module (or including the interface), requires at least a <span>Fortran&#160;2003</span> compiler (F2K3). <span>FORTRAN&#160;77</span> compatibility is only implicitly available (no interface), and the available subset of routines is documented in `libxsmm.f` and marked with [comments](https://github.com/libxsmm/libxsmm/search?q=implementation+provided+for+Fortran+77+compatibility) (part of the implementation).
 
+#### CMake
+
+CMake 3.13 or newer can build the classic library ABI, the optional Fortran module interface, and the generator executables. GNU Make remains the reference build path, especially when the full set of build-time customization options or legacy sample targets is needed.
+
+Configure, build, and install LIBXSMM with:
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/libxsmm-install
+cmake --build build --target install -j
+```
+
+The default CMake build produces static libraries. Add `-DBUILD_SHARED_LIBS=ON` to build shared libraries. When a Fortran compiler is detected, the Fortran module interface and `libxsmmf` are built automatically.
+
+The installed package should be consumed through its exported targets:
+
+```cmake
+find_package(libxsmm CONFIG REQUIRED)
+target_link_libraries(my_target PRIVATE libxsmm::libxsmm)
+```
+
+For the Fortran module interface:
+
+```cmake
+find_package(libxsmm CONFIG REQUIRED COMPONENTS Fortran)
+target_link_libraries(my_target PRIVATE libxsmm::libxsmmf)
+```
+
+For an in-tree dependency, `add_subdirectory()` can be used. An installed package and `find_package(libxsmm CONFIG REQUIRED)` are preferred for regular downstream integration.
+
 ### Header-Only
 
 <span>Version&#160;1.4.4</span> introduced support for "header-only" usage in C and C++. By only including `libxsmm_source.h` allows to get around building the library. However, this gives up on a clearly defined application binary interface (ABI). An ABI may allow for hot-fixes after deploying an application (when relying on the shared library form), and it may also ensure to only rely on the public interface of LIBXSMM. In contrast, the header-only form not only exposes the internal implementation of LIBXSMM but can also increase the turnaround time during development of an application (due to longer compilation times). The header file is intentionally named "libxsmm_**source**.h" since this header file relies on the [src](https://github.com/libxsmm/libxsmm/tree/main/src) directory (with the implications as noted earlier).
@@ -169,31 +200,7 @@ Using the Fortran module (or including the interface), requires at least a <span
 
 ## Rules for building LIBXSMM
 
-LIBXSMM can be used as header-only library, i.e., no source code must be (pre-)built. However, it can be desirable to build LIBXSMM as an intermediate library using a custom setup or build system. The latter can still implement custom build rules to configure LIBXSMM's interface before building the code. More likely, building LIBXSMM from source in a custom fashion can still be omitting to configure the interface and rely on "(zero-config)[#zero-config-abi]", i.e., defining LIBXSMM_DEFAULT_CONFIG (`-DLIBXSMM_DEFAULT_CONFIG`). For example, a CMake module for LIBXSMM can look like:
-
-```cmake
-include(FetchContent)
-FetchContent_Declare(
-  xsmm
-  URL https://github.com/chelini/libxsmm/archive/<your-preferred-revision>.tar.gz
-  URL_HASH SHA256=<sha256sum-corresponding-to-above-revision>
-)
-FetchContent_GetProperties(xsmm)
-if(NOT xsmm_POPULATED)
-  FetchContent_Populate(xsmm)
-endif()
-
-set(LIBXSMMROOT ${xsmm_SOURCE_DIR})
-file(GLOB _GLOB_XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${LIBXSMMROOT}/src/*.c)
-list(REMOVE_ITEM _GLOB_XSMM_SRCS ${LIBXSMMROOT}/src/libxsmm_generator_gemm_driver.c)
-set(XSMM_INCLUDE_DIRS ${LIBXSMMROOT}/include)
-
-add_library(xsmm STATIC ${_GLOB_XSMM_SRCS})
-target_include_directories(xsmm PUBLIC ${XSMM_INCLUDE_DIRS})
-target_compile_definitions(xsmm PUBLIC
-  LIBXSMM_DEFAULT_CONFIG
-)
-```
+Projects using CMake should use the native CMake build described above rather than maintaining a duplicate list of LIBXSMM source files. Other build systems can compile and link LIBXSMM directly. Such builds may generate the configured interfaces first, or opt into zero-config mode by defining `LIBXSMM_DEFAULT_CONFIG` (`-D`). Zero-config mode is not available for LIBXSMM's Fortran interface.
 
 ## Link Instructions
 

--- a/scripts/libxsmmConfig.cmake
+++ b/scripts/libxsmmConfig.cmake
@@ -1,9 +1,9 @@
-include(CMakeFindDependencyMacro)
 include(FindPackageHandleStandardArgs)
 
 get_filename_component(_libxsmm_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
 
 set(LIBXSMM_VERSION "@VERSION@")
+set(_libxsmm_threads "@THREADS@")
 
 set(_libxsmm_suffixes_save "${CMAKE_FIND_LIBRARY_SUFFIXES}")
 if(DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
@@ -20,9 +20,24 @@ unset(_libxsmm_suffixes_save)
 find_path(LIBXSMM_INCLUDE_DIR NAMES libxsmm.h
   HINTS "${_libxsmm_prefix}/include" "${_libxsmm_prefix}" NO_DEFAULT_PATH)
 
-if(LIBXSMM_LIBRARY AND LIBXSMM_INCLUDE_DIR)
-  find_dependency(Threads)
+find_path(LIBXSMM_FORTRAN_MODULE_DIR NAMES libxsmm.mod LIBXSMM.mod
+  HINTS "${_libxsmm_prefix}/include" "${_libxsmm_prefix}" NO_DEFAULT_PATH)
 
+set(_libxsmm_suffixes_save "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+if(DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+endif()
+find_library(LIBXSMM_FORTRAN_LIBRARY NAMES xsmmf
+  HINTS "${_libxsmm_prefix}/lib" NO_DEFAULT_PATH)
+if(NOT LIBXSMM_FORTRAN_LIBRARY)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES "${_libxsmm_suffixes_save}")
+  find_library(LIBXSMM_FORTRAN_LIBRARY NAMES xsmmf
+    HINTS "${_libxsmm_prefix}/lib" NO_DEFAULT_PATH)
+endif()
+set(CMAKE_FIND_LIBRARY_SUFFIXES "${_libxsmm_suffixes_save}")
+unset(_libxsmm_suffixes_save)
+
+if(LIBXSMM_LIBRARY AND LIBXSMM_INCLUDE_DIR)
   if(NOT TARGET libxsmm::libxsmm)
     add_library(libxsmm::libxsmm UNKNOWN IMPORTED)
     set_target_properties(libxsmm::libxsmm PROPERTIES
@@ -30,9 +45,6 @@ if(LIBXSMM_LIBRARY AND LIBXSMM_INCLUDE_DIR)
       INTERFACE_INCLUDE_DIRECTORIES "${LIBXSMM_INCLUDE_DIR}")
 
     set(_libxsmm_interface_libraries "")
-    if(TARGET Threads::Threads)
-      list(APPEND _libxsmm_interface_libraries Threads::Threads)
-    endif()
     if(CMAKE_DL_LIBS)
       list(APPEND _libxsmm_interface_libraries "${CMAKE_DL_LIBS}")
     endif()
@@ -46,14 +58,44 @@ if(LIBXSMM_LIBRARY AND LIBXSMM_INCLUDE_DIR)
         INTERFACE_LINK_LIBRARIES "${_libxsmm_interface_libraries}")
     endif()
     unset(_libxsmm_interface_libraries)
+
+    # Do not call FindThreads here: it requires C or CXX, and therefore
+    # prevents a Fortran-only project from discovering LIBXSMM. Preserve the
+    # thread usage requirements from the GNU Make build directly instead.
+    if(_libxsmm_threads AND UNIX AND NOT APPLE)
+      set_property(TARGET libxsmm::libxsmm APPEND PROPERTY
+        INTERFACE_COMPILE_OPTIONS "-pthread")
+      set_property(TARGET libxsmm::libxsmm APPEND PROPERTY
+        INTERFACE_LINK_OPTIONS "-pthread")
+    endif()
   else()
     set_property(TARGET libxsmm::libxsmm PROPERTY
       IMPORTED_LOCATION "${LIBXSMM_LIBRARY}")
   endif()
 endif()
 
+set(libxsmm_Fortran_FOUND FALSE)
+if(LIBXSMM_FORTRAN_LIBRARY AND LIBXSMM_FORTRAN_MODULE_DIR
+    AND TARGET libxsmm::libxsmm)
+  if(NOT TARGET libxsmm::libxsmmf)
+    add_library(libxsmm::libxsmmf UNKNOWN IMPORTED)
+    set_target_properties(libxsmm::libxsmmf PROPERTIES
+      IMPORTED_LOCATION "${LIBXSMM_FORTRAN_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${LIBXSMM_FORTRAN_MODULE_DIR}"
+      INTERFACE_LINK_LIBRARIES "libxsmm::libxsmm")
+  else()
+    set_property(TARGET libxsmm::libxsmmf PROPERTY
+      IMPORTED_LOCATION "${LIBXSMM_FORTRAN_LIBRARY}")
+  endif()
+  set(libxsmm_Fortran_FOUND TRUE)
+endif()
+
 find_package_handle_standard_args(libxsmm
   REQUIRED_VARS LIBXSMM_LIBRARY LIBXSMM_INCLUDE_DIR
-  VERSION_VAR LIBXSMM_VERSION)
+  VERSION_VAR LIBXSMM_VERSION
+  HANDLE_COMPONENTS)
 
 unset(_libxsmm_prefix)
+unset(_libxsmm_threads)
+unset(LIBXSMM_FORTRAN_LIBRARY)
+unset(LIBXSMM_FORTRAN_MODULE_DIR)

--- a/scripts/libxsmmConfig.cmake.in
+++ b/scripts/libxsmmConfig.cmake.in
@@ -1,12 +1,14 @@
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
-
 set(LIBXSMM_VERSION "@PROJECT_VERSION@")
 set(LIBXSMM_FORTRAN "@LIBXSMM_FORTRAN@")
-find_dependency(Threads)
 set_and_check(LIBXSMM_TARGETS_FILE
   "${CMAKE_CURRENT_LIST_DIR}/libxsmmTargets.cmake")
 include("${LIBXSMM_TARGETS_FILE}")
+
+set(libxsmm_Fortran_FOUND FALSE)
+if(TARGET libxsmm::libxsmmf)
+  set(libxsmm_Fortran_FOUND TRUE)
+endif()
 
 check_required_components(libxsmm)


### PR DESCRIPTION
This improves and makes safe the native CMake package integration for downstream Fortran projects.

Previously, the installed package configuration unconditionally called `find_dependency(Threads)`. Since CMake's `FindThreads` module requires either C or C++ to be enabled, this prevented a pure Fortran project from using:

```cmake
find_package(libxsmm CONFIG REQUIRED)
```

The thread usage requirements are now propagated to the exported LIBXSMM targets directly, so the installed package no longer depends on `Threads::Threads` or invokes `FindThreads` during package discovery.

This also adds support for the optional Fortran component:

```cmake
find_package(libxsmm CONFIG REQUIRED COMPONENTS Fortran)
target_link_libraries(my_target PRIVATE libxsmm::libxsmmf)
```

The component is reported as unavailable when the installed LIBXSMM build does not contain the Fortran interface.

P.S. The README is updated to document the native CMake build, installation, and downstream package usage. GNU Make remains documented as the reference build path, particularly for its broader build-time customization and legacy sample coverage.