### PR TITLE
Clean: Add Transpose-A and strided BRGEMM support for ARM SME

### DIFF
--- a/scripts/buildkite/libxsmm-arm-jetson.yml
+++ b/scripts/buildkite/libxsmm-arm-jetson.yml
@@ -115,3 +115,12 @@ steps:
       LIBXSMM_TARGET: "arm_v82"
       PARTITIONS: "orion"
       TEST_N: 48
+
+  - label: "GEMM (sme512)"
+    command: "scripts/tool_test.sh samples/xgemm/kernel_test.sh"
+    env:
+      SSIZE: 2
+      NP: 12
+      BIN_INSTR_TOOL: "/swtools/armie/latest/bin64/armie -mvl=16 -msvl=64 --"
+      LIBXSMM_TARGET: "appl_m4"
+      PARTITIONS: "orion"

--- a/scripts/buildkite/libxsmm-arm-jetson.yml
+++ b/scripts/buildkite/libxsmm-arm-jetson.yml
@@ -39,6 +39,15 @@ steps:
       LIBXSMM_TARGET: "sve512"
       PARTITIONS: "orion"
 
+  - label: "GEMM (sme512)"
+    command: "scripts/tool_test.sh samples/xgemm/kernel_test.sh"
+    env:
+      SSIZE: 2
+      NP: 12
+      BIN_INSTR_TOOL: "/swtools/armie/latest/bin64/armie -mvl=16 -msvl=64 --"
+      LIBXSMM_TARGET: "appl_m4"
+      PARTITIONS: "orion"
+
   - label: "BCSC SPMM (Neon)"
     command: "scripts/tool_test.sh samples/xgemm_sparse/kernel_test.sh"
     env:
@@ -115,12 +124,3 @@ steps:
       LIBXSMM_TARGET: "arm_v82"
       PARTITIONS: "orion"
       TEST_N: 48
-
-  - label: "GEMM (sme512)"
-    command: "scripts/tool_test.sh samples/xgemm/kernel_test.sh"
-    env:
-      SSIZE: 2
-      NP: 12
-      BIN_INSTR_TOOL: "/swtools/armie/latest/bin64/armie -mvl=16 -msvl=64 --"
-      LIBXSMM_TARGET: "appl_m4"
-      PARTITIONS: "orion"

--- a/src/generator_aarch64_instructions.c
+++ b/src/generator_aarch64_instructions.c
@@ -2383,6 +2383,32 @@ void libxsmm_aarch64_instruction_sm( libxsmm_generated_code* io_generated_code,
 }
 
 LIBXSMM_API_INTERN
+void libxsmm_aarch64_instruction_sme_zero( libxsmm_generated_code* io_generated_code,
+                                           unsigned int            i_mask ) {
+  unsigned int code_head = io_generated_code->code_size/4;
+  unsigned int* code     = (unsigned int *)io_generated_code->generated_code;
+
+  if ( io_generated_code->arch != LIBXSMM_AARCH64_APPL_M4 ) {
+    fprintf(stderr, "libxsmm_aarch64_instruction_sme_zero apple M4 is needed ( or SME )\n");
+    LIBXSMM_EXIT_ERROR(io_generated_code);
+    return;
+  }
+  /* Ensure we have enough space */
+  if ( io_generated_code->buffer_size - io_generated_code->code_size < 4 ) {
+    LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_BUFFER_TOO_SMALL );
+    return;
+  }
+
+  /* ZERO {ZA} : base opcode | 8-bit tile mask (0xff = all ZA tiles) */
+  code[code_head] = LIBXSMM_AARCH64_INSTR_SME_ZERO | (unsigned int)(0xff & i_mask);
+
+  /* advance code head */
+  io_generated_code->code_size += 4;
+
+  return;
+}
+
+LIBXSMM_API_INTERN
 void libxsmm_aarch64_instruction_set_ptrue_as_counter_sve2( libxsmm_generated_code* io_generated_code,
                                                             unsigned int            i_instr,
                                                             unsigned int            i_pred_reg ){

--- a/src/generator_aarch64_instructions.h
+++ b/src/generator_aarch64_instructions.h
@@ -507,6 +507,7 @@
 #define LIBXSMM_AARCH64_INSTR_SVE2_PTRUE_AS_COUNTER           0x25207810
 #define LIBXSMM_AARCH64_INSTR_SME_FMAX_2                      0xc1a0a100
 #define LIBXSMM_AARCH64_INSTR_SME_FMAX_4                      0xc1a0a900
+#define LIBXSMM_AARCH64_INSTR_SME_ZERO                        0xc0080000 /* zero ZA tiles (imm8 mask) */
 
 /**
  * shift mode */
@@ -1052,6 +1053,10 @@ void libxsmm_aarch64_instruction_sme_mova( libxsmm_generated_code* io_generated_
 LIBXSMM_API_INTERN
 void libxsmm_aarch64_instruction_sm( libxsmm_generated_code* io_generated_code,
                                      unsigned int            i_instr );
+
+LIBXSMM_API_INTERN
+void libxsmm_aarch64_instruction_sme_zero( libxsmm_generated_code* io_generated_code,
+                                           unsigned int            i_mask );
 
 LIBXSMM_API_INTERN
 void libxsmm_aarch64_instruction_set_ptrue_as_counter_sve2( libxsmm_generated_code* io_generated_code,

--- a/src/generator_common_aarch64.c
+++ b/src/generator_common_aarch64.c
@@ -4443,13 +4443,20 @@ void libxsmm_generator_load_32x32_aarch64_sme( libxsmm_generated_code* io_genera
                                                     const unsigned int      i_gp_reg_help,
                                                     const unsigned int      i_m_blocking,
                                                     const unsigned int      i_n_blocking,
-                                                    const unsigned int      i_ldc ){
+                                                    const unsigned int      i_ldc,
+                                                    const unsigned int      i_beta0 ){
   unsigned int l_n_count = i_n_blocking;
   unsigned int l_en = 0;
   unsigned int l_em = 0;
   unsigned int l_register_offset = 0;
   unsigned int l_i = 0;
   unsigned int l_n_block_count = (i_n_blocking <= 16) ? 1 : 2;
+
+  /* beta == 0: no C load, zero the ZA accumulator tiles instead */
+  if( i_beta0 != 0 ){
+    libxsmm_aarch64_instruction_sme_zero( io_generated_code, 0xff );
+    return;
+  }
 
   libxsmm_generator_set_w_reg_sme( io_generated_code, 4);
 
@@ -4521,10 +4528,18 @@ void libxsmm_generator_load_64x16_aarch64_sme( libxsmm_generated_code* io_genera
                                                const unsigned int      i_gp_reg_addr,
                                                const unsigned int      i_m_blocking,
                                                const unsigned int      i_n_blocking,
-                                               const unsigned int      i_ldc ){
+                                               const unsigned int      i_ldc,
+                                               const unsigned int      i_beta0 ){
   unsigned int l_block = 0;
   unsigned int l_en = 0;
   unsigned int l_i = 0;
+
+  /* beta == 0: no C load, zero the ZA accumulator tiles instead */
+  if( i_beta0 != 0 ){
+    libxsmm_aarch64_instruction_sme_zero( io_generated_code, 0xff );
+    return;
+  }
+
   libxsmm_generator_set_w_reg_sme( io_generated_code, 4);
   /* set predication register */
   libxsmm_generator_set_pn_register_aarch64_sve2( io_generated_code,
@@ -5359,10 +5374,18 @@ void libxsmm_generated_load_16x64_aarch64_sme( libxsmm_generated_code* io_genera
                                                const unsigned int      i_gp_reg_addr,
                                                const unsigned int      i_m_blocking,
                                                const unsigned int      i_n_blocking,
-                                               const unsigned int      i_ldc ){
+                                               const unsigned int      i_ldc,
+                                               const unsigned int      i_beta0 ){
   unsigned int l_tile_count = i_n_blocking / 16;
   unsigned int l_en = 0;
   unsigned int l_i = 0;
+
+  /* beta == 0: no C load, zero the ZA accumulator tiles instead */
+  if( i_beta0 != 0 ){
+    libxsmm_aarch64_instruction_sme_zero( io_generated_code, 0xff );
+    return;
+  }
+
   if( i_n_blocking % 16 != 0 ){
     l_tile_count++;
   }

--- a/src/generator_common_aarch64.h
+++ b/src/generator_common_aarch64.h
@@ -966,7 +966,8 @@ void libxsmm_generator_load_32x32_aarch64_sme( libxsmm_generated_code* io_genera
                                                const unsigned int      i_gp_reg_help,
                                                const unsigned int      i_m_blocking,
                                                const unsigned int      i_n_blocking,
-                                               const unsigned int      i_ldc );
+                                               const unsigned int      i_ldc,
+                                               const unsigned int      i_beta0 );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_store_32x32_aarch64_sme( libxsmm_generated_code* io_generated_code,
@@ -997,7 +998,8 @@ void libxsmm_generator_load_64x16_aarch64_sme( libxsmm_generated_code* io_genera
                                                const unsigned int      i_gp_reg_addr,
                                                const unsigned int      i_m_blocking,
                                                const unsigned int      i_n_blocking,
-                                               const unsigned int      i_ldc );
+                                               const unsigned int      i_ldc,
+                                               const unsigned int      i_beta0 );
 
 LIBXSMM_API_INTERN
 void libxsmm_generated_store_64x16_aarch64_sme( libxsmm_generated_code* io_generated_code,
@@ -1019,7 +1021,8 @@ void libxsmm_generated_load_16x64_aarch64_sme( libxsmm_generated_code* io_genera
                                                const unsigned int      i_gp_reg_addr,
                                                const unsigned int      i_m_blocking,
                                                const unsigned int      i_n_blocking,
-                                               const unsigned int      i_ldc );
+                                               const unsigned int      i_ldc,
+                                               const unsigned int      i_beta0 );
 
 LIBXSMM_API_INTERN
 void libxsmm_generated_store_16x64_aarch64_sme( libxsmm_generated_code* io_generated_code,

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -1187,10 +1187,17 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   } else if ( (io_generated_code->arch == LIBXSMM_AARCH64_SVE512) || (io_generated_code->arch == LIBXSMM_AARCH64_A64FX) ) {
     libxsmm_generator_gemm_aarch64_kernel( io_generated_code, &l_xgemm_desc_mod );
   } else if ( io_generated_code->arch == LIBXSMM_AARCH64_APPL_M4 ) {
+    const unsigned int l_sme_flags = i_xgemm_desc->flags & ~(unsigned int)LIBXSMM_GEMM_FLAG_BETA_0;
     if( LIBXSMM_DATATYPE_F32 == LIBXSMM_GEMM_GETENUM_AB_COMMON_PREC(l_xgemm_desc_mod.datatype) &&
-        ((i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI ) ||
-         (i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B ) ||
-        (i_xgemm_desc->flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE ) ) ){
+        ((l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_B + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_A ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_A + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_A + LIBXSMM_GEMM_FLAG_TRANS_B ) ||
+         (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_TRANS_A + LIBXSMM_GEMM_FLAG_TRANS_B + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE )
+         ) ){
       libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( io_generated_code, &l_xgemm_desc_mod );
     } else {
       io_generated_code->arch = LIBXSMM_AARCH64_V81;

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -1187,7 +1187,7 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   } else if ( (io_generated_code->arch == LIBXSMM_AARCH64_SVE512) || (io_generated_code->arch == LIBXSMM_AARCH64_A64FX) ) {
     libxsmm_generator_gemm_aarch64_kernel( io_generated_code, &l_xgemm_desc_mod );
   } else if ( io_generated_code->arch == LIBXSMM_AARCH64_APPL_M4 ) {
-    const unsigned int l_sme_flags = i_xgemm_desc->flags & ~(unsigned int)LIBXSMM_GEMM_FLAG_BETA_0;
+    const unsigned int l_sme_flags = l_xgemm_desc_mod.flags & ~(unsigned int)LIBXSMM_GEMM_FLAG_BETA_0;
     if( LIBXSMM_DATATYPE_F32 == LIBXSMM_GEMM_GETENUM_AB_COMMON_PREC(l_xgemm_desc_mod.datatype) &&
         ((l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI ) ||
          (l_sme_flags == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI + LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE ) ||

--- a/src/generator_gemm_sme.c
+++ b/src/generator_gemm_sme.c
@@ -31,6 +31,8 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
                                                    const unsigned int                 i_trans_size ){
   void (*l_generator_microkernel)( libxsmm_generated_code*, const libxsmm_gp_reg_mapping*, const libxsmm_micro_kernel_config*, const libxsmm_gemm_descriptor*,
                                    const unsigned int, const unsigned int );
+  const unsigned int l_trans_size_a = (i_m_blocking > 32) ? 64 : ((i_m_blocking > 16) ? 32 : 16);
+
   if( i_blocking_scheme == 0){
     l_generator_microkernel = libxsmm_generator_gemm_aarch64_microkernel_sme;
   } else if( i_blocking_scheme == 1){
@@ -38,8 +40,6 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
   } else {
     l_generator_microkernel = libxsmm_generator_gemm_aarch64_microkernel_sme_16x64;
   }
-
-  const unsigned int l_trans_size_a = (i_m_blocking > 32) ? 64 : ((i_m_blocking > 16) ? 32 : 16);
 
   /* advance A and B */
   libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code,
@@ -353,7 +353,7 @@ void libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( libxsmm_generated_
                                                  LIBXSMM_AARCH64_GP_REG_X28, 0 );
 
   if( l_is_br ){
-   
+
     libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF,
                                           i_gp_reg_mapping->gp_reg_help_6, LIBXSMM_AARCH64_GP_REG_XZR, 0, i_gp_reg_mapping->gp_reg_help_3 );
     libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, (long long)l_tile_alloc );
@@ -596,7 +596,7 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
 
   /* define loop_label_tracker */
   libxsmm_reset_loop_label_tracker( &l_loop_label_tracker );
-  
+
   /* need more registers here */
   libxsmm_aarch64_instruction_open_stream( io_generated_code, 0xecf );
 

--- a/src/generator_gemm_sme.c
+++ b/src/generator_gemm_sme.c
@@ -39,10 +39,12 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
     l_generator_microkernel = libxsmm_generator_gemm_aarch64_microkernel_sme_16x64;
   }
 
+  const unsigned int l_trans_size_a = (i_m_blocking > 32) ? 64 : ((i_m_blocking > 16) ? 32 : 16);
+
   /* advance A and B */
   libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code,
                                              i_gp_reg_mapping->gp_reg_help_0,
-                                             ((long long)i_xgemm_desc->lda ) * i_micro_kernel_config->datatype_size_in );
+                                             ( ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? (long long)l_trans_size_a : (long long)i_xgemm_desc->lda ) * i_micro_kernel_config->datatype_size_in );
 
   if( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ){
     libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code,
@@ -208,13 +210,21 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
 
   libxsmm_generator_loop_footer_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_kloop, 1 );
 
-  /* reset A pointer */
-  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                 LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                 i_gp_reg_mapping->gp_reg_a,
-                                                 i_gp_reg_mapping->gp_reg_help_0,
-                                                 i_gp_reg_mapping->gp_reg_a,
-                                                 (long long)i_xgemm_desc->k * i_xgemm_desc->lda * i_micro_kernel_config->datatype_size_in );
+  if( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
+                                                   LIBXSMM_AARCH64_INSTR_GP_META_SUB,
+                                                   i_gp_reg_mapping->gp_reg_a_base,
+                                                   i_gp_reg_mapping->gp_reg_help_0,
+                                                   i_gp_reg_mapping->gp_reg_a_base,
+                                                   (long long)i_xgemm_desc->k * l_trans_size_a * i_micro_kernel_config->datatype_size_in );
+  } else {
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
+                                                   LIBXSMM_AARCH64_INSTR_GP_META_SUB,
+                                                   i_gp_reg_mapping->gp_reg_a,
+                                                   i_gp_reg_mapping->gp_reg_help_0,
+                                                   i_gp_reg_mapping->gp_reg_a,
+                                                   (long long)i_xgemm_desc->k * i_xgemm_desc->lda * i_micro_kernel_config->datatype_size_in );
+  }
 
   /* reset B pointer */
   if( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0 ){
@@ -234,11 +244,15 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
   }
 
   if ( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0 ) {
-          /* increment forward counting BRGEMM count */
-    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_2, i_xgemm_desc->c1 );
-    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_scf, i_xgemm_desc->c2 );
+    const unsigned int l_reg_a_br = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? i_gp_reg_mapping->gp_reg_a_base : i_gp_reg_mapping->gp_reg_a;
+    const long long    l_a_stride_br = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? (long long)i_xgemm_desc->k * l_trans_size_a * i_micro_kernel_config->datatype_size_in : (long long)i_xgemm_desc->c1;
+    const long long    l_b_stride_br = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? (long long)i_xgemm_desc->c2 : (long long)i_trans_size * i_xgemm_desc->k * i_micro_kernel_config->datatype_size_in;
+
+    /* increment forward counting BRGEMM count */
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_2, l_a_stride_br );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_scf, l_b_stride_br );
     libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR, i_gp_reg_mapping->gp_reg_help_2,
-                                                          i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_a, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+                                                          l_reg_a_br, l_reg_a_br, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
     if( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0  ) {
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR, i_gp_reg_mapping->gp_reg_scf,
                                                           i_gp_reg_mapping->gp_reg_b, i_gp_reg_mapping->gp_reg_b, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
@@ -255,8 +269,8 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
     libxsmm_generator_loop_footer_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_reduce_loop, 1 );
 
     /* restore A and B register */
-    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR, i_gp_reg_mapping->gp_reg_a,
-                                                          i_gp_reg_mapping->gp_reg_help_4, i_gp_reg_mapping->gp_reg_a, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR, l_reg_a_br,
+                                                          i_gp_reg_mapping->gp_reg_help_4, l_reg_a_br, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
     if( (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0  ) {
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR, i_gp_reg_mapping->gp_reg_b,
                                                             i_gp_reg_mapping->gp_reg_help_5, i_gp_reg_mapping->gp_reg_b, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
@@ -266,6 +280,266 @@ void libxsmm_generator_gemm_aarch64_kloop_sme_het( libxsmm_generated_code*      
     }
   }
 
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_pack_one_a_tile( libxsmm_generated_code*            io_generated_code,
+                                                          libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                          const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                          const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                          const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                          const unsigned int                 i_m_blocking ){
+
+  const unsigned int l_dt           = i_micro_kernel_config->datatype_size_in;
+  const unsigned int l_k            = (unsigned int)i_xgemm_desc->k;
+  const unsigned int l_use_wide     = (i_m_blocking > 32);
+  const unsigned int l_k_chunk      = (i_m_blocking > 16) ? 16 : 32;
+  const unsigned int l_full_ikrest  = l_use_wide ? 0 : l_k_chunk;
+  const unsigned int l_trans_loop   = l_k / l_k_chunk;
+  const unsigned int l_trans_rest   = l_k % l_k_chunk;
+
+  if( l_trans_loop > 0 ){
+    libxsmm_generator_loop_header_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_2, l_trans_loop );
+    if( l_use_wide ){
+      libxsmm_generator_sme_transpose_64( io_generated_code, i_gp_reg_mapping->gp_reg_a, (unsigned int)i_xgemm_desc->lda,
+                                          l_full_ikrest, i_m_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    } else {
+      libxsmm_generator_transpose_sme( io_generated_code, i_gp_reg_mapping->gp_reg_a, (unsigned int)i_xgemm_desc->lda,
+                                       l_full_ikrest, i_m_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    }
+    /* advance the A^T source down K by one chunk */
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_help_1,
+                                                   i_gp_reg_mapping->gp_reg_a, (unsigned long long)l_k_chunk * l_dt );
+    libxsmm_generator_loop_footer_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_2, 1 );
+  }
+  if( l_trans_rest > 0 ){
+    if( l_use_wide ){
+      libxsmm_generator_sme_transpose_64( io_generated_code, i_gp_reg_mapping->gp_reg_a, (unsigned int)i_xgemm_desc->lda,
+                                          l_trans_rest, i_m_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    } else {
+      libxsmm_generator_transpose_sme( io_generated_code, i_gp_reg_mapping->gp_reg_a, (unsigned int)i_xgemm_desc->lda,
+                                       l_trans_rest, i_m_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    }
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_help_1,
+                                                   i_gp_reg_mapping->gp_reg_a, (unsigned long long)l_trans_rest * l_dt );
+  }
+  /* rewind the A^T source pointer back to the start of this M-block -> undo the total K advance */
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
+                                                 i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_help_1,
+                                                 i_gp_reg_mapping->gp_reg_a, (unsigned long long)l_k * l_dt );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( libxsmm_generated_code*            io_generated_code,
+                                                              libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                              const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                              const unsigned int                 i_m_blocking,
+                                                              const unsigned int                 i_b_scratch_ld ){
+
+  const unsigned int l_dt           = i_micro_kernel_config->datatype_size_in;
+  const unsigned int l_k            = (unsigned int)i_xgemm_desc->k;
+  const unsigned int l_trans_size_a = (i_m_blocking > 32) ? 64 : ((i_m_blocking > 16) ? 32 : 16);
+  const unsigned int l_b_ld         = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? 0 : i_b_scratch_ld;
+  const unsigned long long l_tile_alloc = (unsigned long long)(l_b_ld + l_trans_size_a) * l_k * l_dt;
+  const unsigned int l_is_br        = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0);
+
+  /* save the current stack top */
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                 LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                 LIBXSMM_AARCH64_GP_REG_X28, 0 );
+
+  if( l_is_br ){
+   
+    libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF,
+                                          i_gp_reg_mapping->gp_reg_help_6, LIBXSMM_AARCH64_GP_REG_XZR, 0, i_gp_reg_mapping->gp_reg_help_3 );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, (long long)l_tile_alloc );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_MUL,
+                                                         i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_help_3,
+                                                         i_gp_reg_mapping->gp_reg_help_1, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_0,
+                                                   i_gp_reg_mapping->gp_reg_help_2, 0 );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR,
+                                                         i_gp_reg_mapping->gp_reg_help_2, i_gp_reg_mapping->gp_reg_help_1,
+                                                         i_gp_reg_mapping->gp_reg_help_2, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   i_gp_reg_mapping->gp_reg_help_2, i_gp_reg_mapping->gp_reg_help_0,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, 0 );
+
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                   i_gp_reg_mapping->gp_reg_a_base, 0 );
+    libxsmm_aarch64_instruction_register_jump_back_label( io_generated_code, io_loop_label_tracker );
+    libxsmm_generator_gemm_aarch64_sme_pack_one_a_tile( io_generated_code, io_loop_label_tracker,
+                                                         i_gp_reg_mapping, i_micro_kernel_config, i_xgemm_desc, i_m_blocking );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, (long long)i_xgemm_desc->c1 );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
+                                                         i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_a,
+                                                         i_gp_reg_mapping->gp_reg_a, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_generator_loop_footer_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_3, 1 );
+    libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF,
+                                          i_gp_reg_mapping->gp_reg_help_6, LIBXSMM_AARCH64_GP_REG_XZR, 0, i_gp_reg_mapping->gp_reg_help_1 );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_2, (long long)i_xgemm_desc->c1 );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_MUL,
+                                                         i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_help_2,
+                                                         i_gp_reg_mapping->gp_reg_help_1, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR,
+                                                         i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_help_1,
+                                                         i_gp_reg_mapping->gp_reg_a, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+  } else {
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, l_tile_alloc );
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                   i_gp_reg_mapping->gp_reg_a_base, 0 );
+    libxsmm_generator_gemm_aarch64_sme_pack_one_a_tile( io_generated_code, io_loop_label_tracker,
+                                                         i_gp_reg_mapping, i_micro_kernel_config, i_xgemm_desc, i_m_blocking );
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_transpose_a_free( libxsmm_generated_code*       io_generated_code,
+                                                          const libxsmm_gp_reg_mapping* i_gp_reg_mapping ){
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                 LIBXSMM_AARCH64_GP_REG_X28, i_gp_reg_mapping->gp_reg_help_1,
+                                                 LIBXSMM_AARCH64_GP_REG_XSP, 0 );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_pack_one_b_tile( libxsmm_generated_code*            io_generated_code,
+                                                          libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                          const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                          const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                          const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                          const unsigned int                 i_n_blocking ){
+
+  const unsigned int l_dt           = i_micro_kernel_config->datatype_size_in;
+  const unsigned int l_k            = (unsigned int)i_xgemm_desc->k;
+  const unsigned int l_use_wide     = (i_n_blocking > 32);
+  const unsigned int l_k_chunk      = (i_n_blocking > 16) ? 16 : 32;
+  const unsigned int l_full_ikrest  = l_use_wide ? 0 : l_k_chunk;
+  const unsigned int l_trans_loop   = l_k / l_k_chunk;
+  const unsigned int l_trans_rest   = l_k % l_k_chunk;
+
+  if( l_trans_loop > 0 ){
+    libxsmm_generator_loop_header_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_2, l_trans_loop );
+    if( l_use_wide ){
+      libxsmm_generator_sme_transpose_64( io_generated_code, i_gp_reg_mapping->gp_reg_b, (unsigned int)i_xgemm_desc->ldb,
+                                          l_full_ikrest, i_n_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    } else {
+      libxsmm_generator_transpose_sme( io_generated_code, i_gp_reg_mapping->gp_reg_b, (unsigned int)i_xgemm_desc->ldb,
+                                       l_full_ikrest, i_n_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    }
+    /* advance the B source down K by one chunk */
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   i_gp_reg_mapping->gp_reg_b, i_gp_reg_mapping->gp_reg_help_1,
+                                                   i_gp_reg_mapping->gp_reg_b, (unsigned long long)l_k_chunk * l_dt );
+    libxsmm_generator_loop_footer_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_2, 1 );
+  }
+  if( l_trans_rest > 0 ){
+    if( l_use_wide ){
+      libxsmm_generator_sme_transpose_64( io_generated_code, i_gp_reg_mapping->gp_reg_b, (unsigned int)i_xgemm_desc->ldb,
+                                          l_trans_rest, i_n_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    } else {
+      libxsmm_generator_transpose_sme( io_generated_code, i_gp_reg_mapping->gp_reg_b, (unsigned int)i_xgemm_desc->ldb,
+                                       l_trans_rest, i_n_blocking, i_gp_reg_mapping->gp_reg_help_0 );
+    }
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   i_gp_reg_mapping->gp_reg_b, i_gp_reg_mapping->gp_reg_help_1,
+                                                   i_gp_reg_mapping->gp_reg_b, (unsigned long long)l_trans_rest * l_dt );
+  }
+  /* rewind the B source pointer back to the start of this N-block -> undo the total K advance */
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
+                                                 i_gp_reg_mapping->gp_reg_b, i_gp_reg_mapping->gp_reg_help_1,
+                                                 i_gp_reg_mapping->gp_reg_b, (unsigned long long)l_k * l_dt );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( libxsmm_generated_code*            io_generated_code,
+                                                              libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                              const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                              const unsigned int                 i_n_blocking,
+                                                              const unsigned int                 i_is_br,
+                                                              const unsigned int                 i_save_tile_base ){
+  const unsigned int l_dt          = i_micro_kernel_config->datatype_size_in;
+  const unsigned int l_k           = (unsigned int)i_xgemm_desc->k;
+  const unsigned int l_tile_width  = (i_n_blocking > 32) ? 64 : ((i_n_blocking > 16) ? 32 : 16);
+  const unsigned long long l_bsize = (unsigned long long)l_tile_width * l_k * l_dt;
+
+  /* save the current stack pointer */
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                 LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                 i_gp_reg_mapping->gp_reg_help_4, 0 );
+  if( i_is_br ){
+    /* allocate count tiles: XSP -= l_bsize*count */
+    libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF,
+                                          i_gp_reg_mapping->gp_reg_help_6, LIBXSMM_AARCH64_GP_REG_XZR, 0, i_gp_reg_mapping->gp_reg_help_3 );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, (long long)l_bsize );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_MUL,
+                                                         i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_help_3,
+                                                         i_gp_reg_mapping->gp_reg_help_1, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_0,
+                                                   i_gp_reg_mapping->gp_reg_help_2, 0 );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR,
+                                                         i_gp_reg_mapping->gp_reg_help_2, i_gp_reg_mapping->gp_reg_help_1,
+                                                         i_gp_reg_mapping->gp_reg_help_2, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   i_gp_reg_mapping->gp_reg_help_2, i_gp_reg_mapping->gp_reg_help_0,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, 0 );
+  } else {
+    /* allocate a single tile */
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, l_bsize );
+  }
+
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                 LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                 i_gp_reg_mapping->gp_reg_reduce_count, 0 );
+  if( i_save_tile_base ){
+    libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                   LIBXSMM_AARCH64_GP_REG_XSP, i_gp_reg_mapping->gp_reg_help_1,
+                                                   LIBXSMM_AARCH64_GP_REG_X26, 0 );
+  }
+  if( i_is_br ){
+    /* one packed tile per batch */
+    libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF,
+                                          i_gp_reg_mapping->gp_reg_help_6, LIBXSMM_AARCH64_GP_REG_XZR, 0, i_gp_reg_mapping->gp_reg_help_3 );
+    libxsmm_aarch64_instruction_register_jump_back_label( io_generated_code, io_loop_label_tracker );
+    libxsmm_generator_gemm_aarch64_sme_pack_one_b_tile( io_generated_code, io_loop_label_tracker,
+                                                         i_gp_reg_mapping, i_micro_kernel_config, i_xgemm_desc, i_n_blocking );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, (long long)i_xgemm_desc->c2 );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
+                                                         i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_b,
+                                                         i_gp_reg_mapping->gp_reg_b, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_generator_loop_footer_aarch64( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping->gp_reg_help_3, 1 );
+    /* restore real B: b -= count * c2 */
+    libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF,
+                                          i_gp_reg_mapping->gp_reg_help_6, LIBXSMM_AARCH64_GP_REG_XZR, 0, i_gp_reg_mapping->gp_reg_help_1 );
+    libxsmm_aarch64_instruction_alu_set_imm64( io_generated_code, i_gp_reg_mapping->gp_reg_help_2, (long long)i_xgemm_desc->c2 );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_MUL,
+                                                         i_gp_reg_mapping->gp_reg_help_1, i_gp_reg_mapping->gp_reg_help_2,
+                                                         i_gp_reg_mapping->gp_reg_help_1, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+    libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_SR,
+                                                         i_gp_reg_mapping->gp_reg_b, i_gp_reg_mapping->gp_reg_help_1,
+                                                         i_gp_reg_mapping->gp_reg_b, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
+  } else {
+    /* single tile */
+    libxsmm_generator_gemm_aarch64_sme_pack_one_b_tile( io_generated_code, io_loop_label_tracker,
+                                                         i_gp_reg_mapping, i_micro_kernel_config, i_xgemm_desc, i_n_blocking );
+  }
+  /* restore stack top: XSP = help_4 */
+  libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
+                                                 i_gp_reg_mapping->gp_reg_help_4, i_gp_reg_mapping->gp_reg_help_1,
+                                                 LIBXSMM_AARCH64_GP_REG_XSP, 0 );
 }
 
 LIBXSMM_API_INTERN
@@ -282,12 +556,12 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
   unsigned int l_m_rest = 0;
   unsigned int l_n_rest = 0;
   unsigned int l_m_2 = 0;
-  unsigned int l_trans_loop = 0;
-  unsigned int l_trans_rest = 0;
   unsigned int l_perfect_blocking_m = 64;
   unsigned int l_perfect_m_count =0;
   unsigned int l_rest_m = 0;
   unsigned int l_m_blocking = 0;
+  unsigned int l_beta0 = 0;
+  unsigned int l_is_br = 0;
   libxsmm_generator_gemm_aarch64_setup_blocking_sme( i_xgemm_desc,
                                                      l_m_scheme,
                                                      l_n_scheme);
@@ -305,6 +579,7 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
   l_gp_reg_mapping.gp_reg_c = LIBXSMM_AARCH64_GP_REG_X2;
   l_gp_reg_mapping.gp_reg_reduce_count = LIBXSMM_AARCH64_GP_REG_X3;
   l_gp_reg_mapping.gp_reg_a_offset = LIBXSMM_AARCH64_GP_REG_X4;
+  l_gp_reg_mapping.gp_reg_a_base = LIBXSMM_AARCH64_GP_REG_X27;
   l_gp_reg_mapping.gp_reg_b_offset = LIBXSMM_AARCH64_GP_REG_X5;
   l_gp_reg_mapping.gp_reg_mloop = LIBXSMM_AARCH64_GP_REG_X6;
   l_gp_reg_mapping.gp_reg_nloop = LIBXSMM_AARCH64_GP_REG_X7;
@@ -321,11 +596,14 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
 
   /* define loop_label_tracker */
   libxsmm_reset_loop_label_tracker( &l_loop_label_tracker );
-
-  libxsmm_aarch64_instruction_open_stream( io_generated_code, 0xe0f );
+  
+  /* need more registers here */
+  libxsmm_aarch64_instruction_open_stream( io_generated_code, 0xecf );
 
   l_new_xgemm_desc_opa = *i_xgemm_desc;
   l_xgemm_desc_opa = (libxsmm_gemm_descriptor*) &l_new_xgemm_desc_opa;
+  l_beta0 = (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BETA_0);
+  l_is_br = ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0);
 
   if( l_m_scheme[1] > 0 ){
     l_m_rest = l_xgemm_desc_opa->m - l_m_scheme[0]*32;
@@ -359,8 +637,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                             l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_AARCH64_GP_REG_UNDEF, 16, l_gp_reg_mapping.gp_reg_help_6 );
   }
 
-  /* setting up the stack frame */
-  libxsmm_generator_gemm_setup_stack_frame_aarch64( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config);
+  {
+    libxsmm_gemm_descriptor l_stack_desc = *i_xgemm_desc;
+    l_stack_desc.flags &= ~(unsigned int)LIBXSMM_GEMM_FLAG_TRANS_A;
+    libxsmm_generator_gemm_setup_stack_frame_aarch64( io_generated_code, &l_stack_desc, &l_gp_reg_mapping, &l_micro_kernel_config);
+  }
 
   libxsmm_aarch64_instruction_sm( io_generated_code,
                                   LIBXSMM_AARCH64_INSTR_SME_SMSTART);
@@ -377,79 +658,9 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
 
 
     if ( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0 ){
-      /* save address of stackpointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    0);
-      /* allocate memory on stack for transposed B */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    (unsigned long long)64 * l_micro_kernel_config.datatype_size_in * l_xgemm_desc_opa->k );
-
-      /* store address of stack pointer to transposed B register ( x3 )*/
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_reduce_count ,
-                                                    0);
-      /* store address into x26 */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_X26,
-                                                    0);
-
-      l_trans_loop = l_xgemm_desc_opa->k / 16;
-      l_trans_rest = l_xgemm_desc_opa->k % 16;
-
-      if( l_trans_loop > 0 ){
-        libxsmm_generator_loop_header_aarch64(io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, l_trans_loop);
-
-        libxsmm_generator_sme_transpose_64( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            0,
-                                            64,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-
-        /* advance pointer B */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                      LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                      l_gp_reg_mapping.gp_reg_b,
-                                                      l_gp_reg_mapping.gp_reg_help_0,
-                                                      l_gp_reg_mapping.gp_reg_b ,
-                                                      (long long )16*l_micro_kernel_config.datatype_size_in );
-        libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, 1 );
-      }
-      if( l_trans_rest > 0 ){
-        libxsmm_generator_sme_transpose_64( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            l_trans_rest,
-                                            64,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-      }
-      /* reset address of stackpointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    0);
-      /* reset b pointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                    l_gp_reg_mapping.gp_reg_b,
-                                                    l_gp_reg_mapping.gp_reg_help_0,
-                                                    l_gp_reg_mapping.gp_reg_b ,
-                                                    ((unsigned long long)(l_xgemm_desc_opa->k - l_trans_rest)) * l_micro_kernel_config.datatype_size_in );
+      libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                               &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                               l_xgemm_desc_opa, 64, l_is_br, 1 );
     } else {
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                     LIBXSMM_AARCH64_INSTR_GP_META_ADD,
@@ -465,6 +676,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                             &l_loop_label_tracker,
                                             l_gp_reg_mapping.gp_reg_mloop,
                                             l_m_scheme[0] * 32 );
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, 32, 64 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                             LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -488,7 +704,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                           l_gp_reg_mapping.gp_reg_help_0,
                                                           32,
                                                           32,
-                                                          l_xgemm_desc_opa->ldc );
+                                                          l_xgemm_desc_opa->ldc ,
+                                                          l_beta0 );
 
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
@@ -583,7 +800,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                           l_gp_reg_mapping.gp_reg_help_0,
                                                           32,
                                                           32,
-                                                          l_xgemm_desc_opa->ldc );
+                                                          l_xgemm_desc_opa->ldc ,
+                                                          l_beta0 );
 
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
@@ -657,7 +875,13 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                     l_gp_reg_mapping.gp_reg_a,
                                                     LIBXSMM_AARCH64_GP_REG_X11,
                                                     l_gp_reg_mapping.gp_reg_a,
-                                                    (long long) 32*l_micro_kernel_config.datatype_size_in );
+                                                    ( ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                        (long long) 32*l_xgemm_desc_opa->lda : (long long) 32 ) * l_micro_kernel_config.datatype_size_in );
+
+      /* free the packed-A stack region */
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* close M loop */
         libxsmm_generator_loop_footer_aarch64( io_generated_code,
@@ -668,6 +892,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
 
     /* rest of M */
     if( l_m_scheme[1] > 0 && l_m_rest < 17 ){
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_rest, 64 );
+      }
       /* save pointer of x2 to x17 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                           LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -681,7 +910,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                 l_gp_reg_mapping.gp_reg_c,
                                                 l_m_rest,
                                                 64,
-                                                l_xgemm_desc_opa->ldc );
+                                                l_xgemm_desc_opa->ldc ,
+                                                l_beta0 );
 
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
                                                     &l_loop_label_tracker,
@@ -692,6 +922,10 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                     64,
                                                     2,
                                                     64 );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* reset C pointer */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
@@ -718,6 +952,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                           LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
     } else if( l_m_scheme[1] > 0 && l_m_rest > 16){
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_rest, 64 );
+      }
       /* save pointer of x2 to x17 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                             LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -741,7 +980,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                           l_gp_reg_mapping.gp_reg_help_0,
                                                           l_m_rest,
                                                           32,
-                                                          l_xgemm_desc_opa->ldc );
+                                                          l_xgemm_desc_opa->ldc ,
+                                                          l_beta0 );
 
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
@@ -836,7 +1076,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                           l_gp_reg_mapping.gp_reg_help_0,
                                                           l_m_rest,
                                                           32,
-                                                          l_xgemm_desc_opa->ldc );
+                                                          l_xgemm_desc_opa->ldc,
+                                                          l_beta0 );
 
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
@@ -880,6 +1121,10 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                           0,
                                                           LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
+
       /* reset B */
       if((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0){
         libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
@@ -911,7 +1156,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                   l_gp_reg_mapping.gp_reg_a,
                                                   l_gp_reg_mapping.gp_reg_help_0,
                                                   l_gp_reg_mapping.gp_reg_a,
-                                                  (long long) l_m_scheme[0] * 32 * l_micro_kernel_config.datatype_size_in );
+                                                  (((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                  (long long) l_m_scheme[0] * 32 * l_xgemm_desc_opa->lda : (long long) l_m_scheme[0] * 32 ) * l_micro_kernel_config.datatype_size_in );
 
     /* advance B */
     if ( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0 ){
@@ -946,85 +1192,9 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
 
   if( l_n_rest > 0 && l_n_rest < 17){
     if ( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0 ){
-        /* save address of stackpointer */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       0);
-
-        /* allocate memory on stack for transposed B */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       (long long) 16 * l_xgemm_desc_opa->k * l_micro_kernel_config.datatype_size_in );
-        /* store address of stack pointer to transposed B register ( x3 )*/
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_reduce_count,
-                                                      0);
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       l_gp_reg_mapping.gp_reg_reduce_count,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       0);
-
-        l_trans_loop = l_xgemm_desc_opa->k / 32;
-        l_trans_rest = l_xgemm_desc_opa->k % 32;
-
-        if( l_trans_loop > 0 ){
-          libxsmm_generator_loop_header_aarch64(io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, l_trans_loop);
-
-          libxsmm_generator_transpose_sme( io_generated_code,
-                                           l_gp_reg_mapping.gp_reg_b,
-                                           l_xgemm_desc_opa->ldb,
-                                           32,
-                                           l_n_rest,
-                                           l_gp_reg_mapping.gp_reg_help_0 );
-          /* advance pointer B */
-          libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                         LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         l_gp_reg_mapping.gp_reg_help_1,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         (unsigned long long)32*l_micro_kernel_config.datatype_size_in );
-          libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, 1 );
-        }
-        if(l_trans_rest > 0 ){
-          libxsmm_generator_transpose_sme( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            l_trans_rest,
-                                            l_n_rest,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-          /* advance pointer B */
-          libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                         LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         l_gp_reg_mapping.gp_reg_help_1,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         (unsigned long long)l_trans_rest*l_micro_kernel_config.datatype_size_in );
-        }
-        /* reset address of stackpointer */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       0);
-        /* reset b pointer */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                       l_gp_reg_mapping.gp_reg_b,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_b ,
-                                                       (long long) l_xgemm_desc_opa->k * l_micro_kernel_config.datatype_size_in );
+      libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                               &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                               l_xgemm_desc_opa, l_n_rest, l_is_br, 0 );
     }
 
     l_perfect_blocking_m = 64;
@@ -1040,6 +1210,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                              l_gp_reg_mapping.gp_reg_mloop,
                                              (l_m_2 == 0) ? (l_perfect_blocking_m * l_perfect_m_count) : l_rest_m );
 
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_blocking, 16 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                            LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -1063,7 +1238,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                 l_gp_reg_mapping.gp_reg_c,
                                                 l_m_blocking,
                                                 l_n_rest,
-                                                l_xgemm_desc_opa->ldc );
+                                                l_xgemm_desc_opa->ldc,
+                                                l_beta0 );
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
                                                     &l_loop_label_tracker,
@@ -1118,7 +1294,12 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                      l_gp_reg_mapping.gp_reg_a,
                                                      l_gp_reg_mapping.gp_reg_help_0,
                                                      l_gp_reg_mapping.gp_reg_a,
-                                                     (long long)l_m_blocking*l_micro_kernel_config.datatype_size_out );
+                                                     ( ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                     (long long)l_m_blocking*l_xgemm_desc_opa->lda : (long long)l_m_blocking ) * l_micro_kernel_config.datatype_size_out );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* close M loop */
       libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker,
@@ -1127,81 +1308,9 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
   } else if( l_n_rest > 16 && l_n_rest < 33){
 
       if ( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0 ){
-        /* save address of stackpointer */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                      0);
-
-        /* allocate memory on stack for transposed B */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       (unsigned long long)32 * l_xgemm_desc_opa->k * l_micro_kernel_config.datatype_size_out);
-        /* store address of stack pointer to transposed B register ( x3 )*/
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_reduce_count,
-                                                       0);
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       l_gp_reg_mapping.gp_reg_reduce_count,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       0);
-
-        l_trans_loop = l_xgemm_desc_opa->k / 16 ;
-        l_trans_rest = l_xgemm_desc_opa->k % 16 ;
-
-        if( l_trans_loop > 0 ){
-        libxsmm_generator_loop_header_aarch64(io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, l_trans_loop);
-          libxsmm_generator_transpose_sme( io_generated_code,
-                                           l_gp_reg_mapping.gp_reg_b,
-                                           l_xgemm_desc_opa->ldb,
-                                           16,
-                                           l_n_rest,
-                                           l_gp_reg_mapping.gp_reg_help_0 );
-          /* advance pointer B */
-          libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                         LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         l_gp_reg_mapping.gp_reg_help_1,
-                                                         l_gp_reg_mapping.gp_reg_b ,
-                                                         (unsigned long long)16*l_micro_kernel_config.datatype_size_in );
-        libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, 1 );
-        }
-        if(l_trans_rest > 0 ){
-          libxsmm_generator_transpose_sme( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            l_trans_rest,
-                                            l_n_rest,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-          /* advance pointer B */
-          libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                         LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         l_gp_reg_mapping.gp_reg_help_1,
-                                                         l_gp_reg_mapping.gp_reg_b,
-                                                         (unsigned long long)l_trans_rest*l_micro_kernel_config.datatype_size_in);
-        }
-        /* reset address of stackpointer */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                       LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       l_gp_reg_mapping.gp_reg_help_1,
-                                                       LIBXSMM_AARCH64_GP_REG_XSP,
-                                                       0);
-        /* reset b pointer */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                          l_gp_reg_mapping.gp_reg_b, l_gp_reg_mapping.gp_reg_help_1, l_gp_reg_mapping.gp_reg_b ,
-                                                          (unsigned long long)l_xgemm_desc_opa->k * l_micro_kernel_config.datatype_size_in );
+        libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_n_rest, l_is_br, 0 );
       }
     l_perfect_blocking_m = 32;
     l_perfect_m_count = l_xgemm_desc_opa->m / 32;
@@ -1218,6 +1327,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                              l_gp_reg_mapping.gp_reg_mloop,
                                              (l_m_2 == 0) ? (l_perfect_blocking_m * l_perfect_m_count) : l_rest_m );
 
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_blocking, 32 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                            LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -1242,7 +1356,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                     l_gp_reg_mapping.gp_reg_help_0,
                                                     l_m_blocking,
                                                     l_n_rest,
-                                                    l_xgemm_desc_opa->ldc );
+                                                    l_xgemm_desc_opa->ldc,
+                                                    l_beta0 );
 
 
       /* compute outer product */
@@ -1301,7 +1416,12 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                      l_gp_reg_mapping.gp_reg_a,
                                                      l_gp_reg_mapping.gp_reg_help_0,
                                                      l_gp_reg_mapping.gp_reg_a,
-                                                     (long long)l_m_blocking*l_micro_kernel_config.datatype_size_in );
+                                                     ( ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                         (long long)l_m_blocking*l_xgemm_desc_opa->lda : (long long)l_m_blocking ) * l_micro_kernel_config.datatype_size_in );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* close M loop */
       libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker,
@@ -1309,77 +1429,9 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
     }
   } else if( l_n_rest > 32 && l_n_rest <= 48 && l_xgemm_desc_opa->m > 16 ){
     if ( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0 ){
-      /* save address of stackpointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    0);
-      /* allocate memory on stack for transposed B */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    (long long) 64 * l_micro_kernel_config.datatype_size_in * l_xgemm_desc_opa->k );
-
-      /* store address of stack pointer to transposed B register ( x3 )*/
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_reduce_count ,
-                                                    0);
-      /* store address into x26 */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_X26,
-                                                    0);
-      l_trans_loop = l_xgemm_desc_opa->k / 16;
-      l_trans_rest = l_xgemm_desc_opa->k % 16;
-      if( l_trans_loop > 0 ){
-        libxsmm_generator_loop_header_aarch64(io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, l_trans_loop);
-
-        libxsmm_generator_sme_transpose_64( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            0,
-                                            l_n_rest,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-
-        /* advance pointer B */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                      LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                      l_gp_reg_mapping.gp_reg_b,
-                                                      l_gp_reg_mapping.gp_reg_help_0,
-                                                      l_gp_reg_mapping.gp_reg_b ,
-                                                      (unsigned long long)16*l_micro_kernel_config.datatype_size_in );
-        libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, 1 );
-      }
-      if( l_trans_rest > 0 ){
-        libxsmm_generator_sme_transpose_64( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            l_trans_rest,
-                                            l_n_rest,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-      }
-      /* reset address of stackpointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    0);
-      /* reset b pointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                    l_gp_reg_mapping.gp_reg_b,
-                                                    l_gp_reg_mapping.gp_reg_help_0,
-                                                    l_gp_reg_mapping.gp_reg_b ,
-                                                    ((unsigned long long)(l_xgemm_desc_opa->k - l_trans_rest)) * l_micro_kernel_config.datatype_size_in );
+      libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                               &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                               l_xgemm_desc_opa, l_n_rest, l_is_br, 0 );
     }
 
     l_perfect_blocking_m = 32;
@@ -1397,6 +1449,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                              l_gp_reg_mapping.gp_reg_mloop,
                                              (l_m_2 == 0) ? (l_perfect_blocking_m * l_perfect_m_count) : l_rest_m );
 
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_blocking, 64 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                            LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -1421,7 +1478,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                     l_gp_reg_mapping.gp_reg_help_0,
                                                     l_m_blocking,
                                                     l_n_rest,
-                                                    l_xgemm_desc_opa->ldc );
+                                                    l_xgemm_desc_opa->ldc,
+                                                    l_beta0 );
 
 
       /* compute outer product */
@@ -1480,13 +1538,23 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                      l_gp_reg_mapping.gp_reg_a,
                                                      l_gp_reg_mapping.gp_reg_help_0,
                                                      l_gp_reg_mapping.gp_reg_a,
-                                                     (long long)l_m_blocking*l_micro_kernel_config.datatype_size_in );
+                                                     ( ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                     (long long)l_m_blocking*l_xgemm_desc_opa->lda : (long long)l_m_blocking ) * l_micro_kernel_config.datatype_size_in );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* close M loop */
       libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker,
                                              l_gp_reg_mapping.gp_reg_mloop, l_m_blocking );
     }
     if( l_xgemm_desc_opa->m % 32 > 0 && l_xgemm_desc_opa->m % 32 <= 16 ){
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_xgemm_desc_opa->m % 32, 64 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                            LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -1501,7 +1569,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                 l_gp_reg_mapping.gp_reg_c,
                                                 l_xgemm_desc_opa->m % 32,
                                                 l_n_rest,
-                                                l_xgemm_desc_opa->ldc );
+                                                l_xgemm_desc_opa->ldc,
+                                                l_beta0 );
 
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
@@ -1537,21 +1606,27 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                            l_gp_reg_mapping.gp_reg_c,
                                                            0,
                                                            LIBXSMM_AARCH64_SHIFTMODE_LSL );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
     }
-    /* restore A pointer */
+    /* restore A pointer to column 0 for the next (16-wide) N part; transposed A rewinds by columns*lda */
     if(  l_xgemm_desc_opa->m % 32 > 0 && l_xgemm_desc_opa->m % 32 <= 16 ){
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                    LIBXSMM_AARCH64_INSTR_GP_META_SUB,
                                                    l_gp_reg_mapping.gp_reg_a,
                                                    l_gp_reg_mapping.gp_reg_help_0,
                                                    l_gp_reg_mapping.gp_reg_a,
-                                                   (l_perfect_m_count > 0 ) ? (long long)l_perfect_blocking_m*l_perfect_m_count*l_micro_kernel_config.datatype_size_in  : (long long) l_xgemm_desc_opa->m*l_micro_kernel_config.datatype_size_in );
+                                                   (((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? (long long)l_xgemm_desc_opa->lda : (long long)1 ) *
+                                                   ((l_perfect_m_count > 0 ) ? (long long)l_perfect_blocking_m*l_perfect_m_count : (long long) l_xgemm_desc_opa->m ) * l_micro_kernel_config.datatype_size_in );
     } else {
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                     LIBXSMM_AARCH64_INSTR_GP_META_SUB,
                                                     l_gp_reg_mapping.gp_reg_a,
                                                     l_gp_reg_mapping.gp_reg_help_0,
                                                     l_gp_reg_mapping.gp_reg_a,
+                                                    (((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? (long long)l_xgemm_desc_opa->lda : (long long)1 ) *
                                                     (long long)l_xgemm_desc_opa->m * l_micro_kernel_config.datatype_size_in );
     }
     /* advance B pointer */
@@ -1613,6 +1688,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                              l_gp_reg_mapping.gp_reg_mloop,
                                              (l_m_2 == 0) ? (l_perfect_blocking_m * l_perfect_m_count) : l_rest_m );
 
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_blocking, 64 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                            LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -1636,7 +1716,8 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                 l_gp_reg_mapping.gp_reg_c,
                                                 l_m_blocking,
                                                 l_n_rest-32,
-                                                l_xgemm_desc_opa->ldc );
+                                                l_xgemm_desc_opa->ldc,
+                                                l_beta0 );
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code,
                                                     &l_loop_label_tracker,
@@ -1685,13 +1766,18 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                      l_gp_reg_mapping.gp_reg_c,
                                                      (long long)l_m_blocking*l_micro_kernel_config.datatype_size_out );
 
-      /* advance A pointer */
+      /* advance A pointer: transposed A steps l_m_blocking columns = *lda */
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
                                                      LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                      l_gp_reg_mapping.gp_reg_a,
                                                      l_gp_reg_mapping.gp_reg_help_0,
                                                      l_gp_reg_mapping.gp_reg_a,
-                                                     (long long)l_m_blocking*l_micro_kernel_config.datatype_size_out );
+                                                     (((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                     (long long)l_m_blocking*l_xgemm_desc_opa->lda : (long long)l_m_blocking ) * l_micro_kernel_config.datatype_size_out );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* close M loop */
       libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker,
@@ -1701,78 +1787,9 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
   } else if( l_n_rest > 32 ){
 
     if ( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_B) == 0 ){
-      /* save address of stackpointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    0);
-      /* allocate memory on stack for transposed B */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    (long long) 64 * l_micro_kernel_config.datatype_size_in * l_xgemm_desc_opa->k );
-
-      /* store address of stack pointer to transposed B register ( x3 )*/
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_reduce_count ,
-                                                    0);
-      /* store address into x26 */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_X26,
-                                                    0);
-
-      l_trans_loop = l_xgemm_desc_opa->k / 16;
-      l_trans_rest = l_xgemm_desc_opa->k % 16;
-      if( l_trans_loop > 0 ){
-        libxsmm_generator_loop_header_aarch64(io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, l_trans_loop);
-
-        libxsmm_generator_sme_transpose_64( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            0,
-                                            l_n_rest,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-
-        /* advance pointer B */
-        libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                      LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                      l_gp_reg_mapping.gp_reg_b,
-                                                      l_gp_reg_mapping.gp_reg_help_0,
-                                                      l_gp_reg_mapping.gp_reg_b ,
-                                                      (unsigned long long)16*l_micro_kernel_config.datatype_size_in );
-        libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker, l_gp_reg_mapping.gp_reg_help_2, 1 );
-      }
-      if( l_trans_rest > 0 ){
-        libxsmm_generator_sme_transpose_64( io_generated_code,
-                                            l_gp_reg_mapping.gp_reg_b,
-                                            l_xgemm_desc_opa->ldb,
-                                            l_trans_rest,
-                                            l_n_rest,
-                                            l_gp_reg_mapping.gp_reg_help_0 );
-      }
-      /* reset address of stackpointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code,
-                                                    LIBXSMM_AARCH64_INSTR_GP_META_ADD,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    l_gp_reg_mapping.gp_reg_help_1,
-                                                    LIBXSMM_AARCH64_GP_REG_XSP,
-                                                    0);
-      /* reset b pointer */
-      libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_SUB,
-                                                    l_gp_reg_mapping.gp_reg_b,
-                                                    l_gp_reg_mapping.gp_reg_help_0,
-                                                    l_gp_reg_mapping.gp_reg_b ,
-                                                    ((unsigned long long)(l_xgemm_desc_opa->k - l_trans_rest)) * l_micro_kernel_config.datatype_size_in );
+      libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                               &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                               l_xgemm_desc_opa, l_n_rest, l_is_br, 0 );
     }
     l_perfect_blocking_m = 16;
     l_perfect_m_count = l_xgemm_desc_opa->m / 16;
@@ -1787,6 +1804,11 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
       libxsmm_generator_loop_header_aarch64( io_generated_code, &l_loop_label_tracker,
                                              l_gp_reg_mapping.gp_reg_mloop, (l_m_2 == 0) ? (l_perfect_blocking_m * l_perfect_m_count) : l_rest_m );
 
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( io_generated_code, &l_loop_label_tracker,
+                                                                 &l_gp_reg_mapping, &l_micro_kernel_config,
+                                                                 l_xgemm_desc_opa, l_m_blocking, 64 );
+      }
       /* save pointer of x2 */
       libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                            LIBXSMM_AARCH64_INSTR_GP_ORR_SR,
@@ -1801,7 +1823,7 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
                                                 l_gp_reg_mapping.gp_reg_c,
                                                 l_m_blocking,
                                                 l_n_rest,
-                                                l_xgemm_desc_opa->ldc );
+                                                l_xgemm_desc_opa->ldc , l_beta0 );
 
       /* compute outer product */
       libxsmm_generator_gemm_aarch64_kloop_sme_het( io_generated_code, &l_loop_label_tracker, &l_gp_reg_mapping, &l_micro_kernel_config,
@@ -1838,7 +1860,12 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
       /* advance A pointer */
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                      l_gp_reg_mapping.gp_reg_a, l_gp_reg_mapping.gp_reg_help_0, l_gp_reg_mapping.gp_reg_a,
-                                                     (long long)l_m_blocking*l_micro_kernel_config.datatype_size_in );
+                                                     (((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ?
+                                                     (long long)l_m_blocking*l_xgemm_desc_opa->lda : (long long)l_m_blocking ) * l_micro_kernel_config.datatype_size_in );
+
+      if( (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ){
+        libxsmm_generator_gemm_aarch64_sme_transpose_a_free( io_generated_code, &l_gp_reg_mapping );
+      }
 
       /* close M loop */
       libxsmm_generator_loop_footer_aarch64( io_generated_code, &l_loop_label_tracker,
@@ -1854,6 +1881,6 @@ void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_c
   libxsmm_generator_gemm_destroy_stack_frame_aarch64( io_generated_code );
 
   /* close asm */
-  libxsmm_aarch64_instruction_close_stream( io_generated_code, 0xe0f );
+  libxsmm_aarch64_instruction_close_stream( io_generated_code, 0xecf );
 
 }

--- a/src/generator_gemm_sme.h
+++ b/src/generator_gemm_sme.h
@@ -29,4 +29,45 @@ LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_aarch64_kernel_sme_het_blocking( libxsmm_generated_code*        io_generated_code,
                                                              const libxsmm_gemm_descriptor* i_xgemm_desc );
 
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_pack_one_a_tile( libxsmm_generated_code*            io_generated_code,
+                                                         libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                         const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                         const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                         const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                         const unsigned int                 i_m_blocking );
+
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_transpose_a_to_stack( libxsmm_generated_code*            io_generated_code,
+                                                              libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                              const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                              const unsigned int                 i_m_blocking,
+                                                              const unsigned int                 i_b_scratch_ld );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_transpose_a_free( libxsmm_generated_code*       io_generated_code,
+                                                          const libxsmm_gp_reg_mapping* i_gp_reg_mapping );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_pack_one_b_tile( libxsmm_generated_code*            io_generated_code,
+                                                         libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                         const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                         const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                         const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                         const unsigned int                 i_n_blocking );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_aarch64_sme_transpose_b_to_stack( libxsmm_generated_code*            io_generated_code,
+                                                              libxsmm_loop_label_tracker*        io_loop_label_tracker,
+                                                              const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+                                                              const libxsmm_micro_kernel_config* i_micro_kernel_config,
+                                                              const libxsmm_gemm_descriptor*     i_xgemm_desc,
+                                                              const unsigned int                 i_n_blocking,
+                                                              const unsigned int                 i_is_br,
+                                                              const unsigned int                 i_save_tile_base );
+
 #endif /* GENERATOR_GEMM_SME_H */

--- a/src/generator_gemm_sme_microkernel.c
+++ b/src/generator_gemm_sme_microkernel.c
@@ -23,30 +23,32 @@ void libxsmm_generator_gemm_aarch64_microkernel_sme( libxsmm_generated_code*    
                                                      const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                      const unsigned int                 i_m_blocking,
                                                      const unsigned int                 i_n_blocking ){
+  const unsigned int l_reg_a = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? i_gp_reg_mapping->gp_reg_a_base : i_gp_reg_mapping->gp_reg_a;
+  const unsigned int l_reg_b = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count;
   /* load A and B */
   libxsmm_aarch64_instruction_sme_mov( io_generated_code,
                                        LIBXSMM_AARCH64_INSTR_SVE2_LD1W_2,
                                        0,
-                                       i_gp_reg_mapping->gp_reg_a,
+                                       l_reg_a,
                                        0,
                                        LIBXSMM_AARCH64_SVE_REG_P8);
 
   libxsmm_aarch64_instruction_sme_mov( io_generated_code,
                                        LIBXSMM_AARCH64_INSTR_SVE2_LD1W_2,
                                        2,
-                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                       l_reg_b,
                                        0,
                                        LIBXSMM_AARCH64_SVE_REG_P9);
 
   /* update pointer */
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
-                                                        i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_a,
+                                                        l_reg_a, i_gp_reg_mapping->gp_reg_help_0, l_reg_a,
                                                         0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
-                                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                                       l_reg_b,
                                                        i_gp_reg_mapping->gp_reg_help_1,
-                                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                                       l_reg_b,
                                                        0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
 
@@ -95,16 +97,18 @@ void libxsmm_generator_gemm_aarch64_microkernel_sme_64x16( libxsmm_generated_cod
                                                            const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                            const unsigned int                 i_m_blocking,
                                                            const unsigned int                 i_n_blocking ){
+  const unsigned int l_reg_a = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? i_gp_reg_mapping->gp_reg_a_base : i_gp_reg_mapping->gp_reg_a;
+  const unsigned int l_reg_b = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count;
    /* load A and B */
   libxsmm_aarch64_instruction_sme_mov( io_generated_code,
                                        LIBXSMM_AARCH64_INSTR_SVE2_LD1W_4,
                                        0,
-                                       i_gp_reg_mapping->gp_reg_a,
+                                       l_reg_a,
                                        0,
                                        LIBXSMM_AARCH64_SVE_REG_P8);
    libxsmm_aarch64_instruction_sve_move( io_generated_code,
                                          LIBXSMM_AARCH64_INSTR_SVE_LD1W_I_OFF,
-                                         ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                         l_reg_b,
                                          0,
                                          0,
                                          LIBXSMM_AARCH64_SVE_REG_Z4,
@@ -112,13 +116,13 @@ void libxsmm_generator_gemm_aarch64_microkernel_sme_64x16( libxsmm_generated_cod
 
   /* update pointer */
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
-                                                        i_gp_reg_mapping->gp_reg_a, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_a,
+                                                        l_reg_a, i_gp_reg_mapping->gp_reg_help_0, l_reg_a,
                                                         0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
-                                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                                       l_reg_b,
                                                        i_gp_reg_mapping->gp_reg_help_1,
-                                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                                       l_reg_b,
                                                        0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
   /* compute fmopa */
@@ -165,10 +169,12 @@ void libxsmm_generator_gemm_aarch64_microkernel_sme_16x64( libxsmm_generated_cod
                                                            const libxsmm_gemm_descriptor*     i_xgemm_desc,
                                                            const unsigned int                 i_m_blocking,
                                                            const unsigned int                 i_n_blocking ){
+  const unsigned int l_reg_a = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0) ? i_gp_reg_mapping->gp_reg_a_base : i_gp_reg_mapping->gp_reg_a;
+  const unsigned int l_reg_b = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count;
   /* load A and B */
   libxsmm_aarch64_instruction_sve_move( io_generated_code,
                                         LIBXSMM_AARCH64_INSTR_SVE_LD1W_I_OFF,
-                                        i_gp_reg_mapping->gp_reg_a,
+                                        l_reg_a,
                                         0,
                                         0,
                                         LIBXSMM_AARCH64_SVE_REG_Z4,
@@ -176,22 +182,22 @@ void libxsmm_generator_gemm_aarch64_microkernel_sme_16x64( libxsmm_generated_cod
   libxsmm_aarch64_instruction_sme_mov( io_generated_code,
                                        LIBXSMM_AARCH64_INSTR_SVE2_LD1W_4,
                                        0,
-                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                       l_reg_b,
                                        0,
                                        LIBXSMM_AARCH64_SVE_REG_P8);
   /* update pointer */
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                        LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
-                                                       i_gp_reg_mapping->gp_reg_a,
+                                                       l_reg_a,
                                                        i_gp_reg_mapping->gp_reg_help_0,
-                                                       i_gp_reg_mapping->gp_reg_a,
+                                                       l_reg_a,
                                                         0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code,
                                                        LIBXSMM_AARCH64_INSTR_GP_ADD_SR,
-                                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                                       l_reg_b,
                                                        i_gp_reg_mapping->gp_reg_help_1,
-                                                       ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_B) > 0) ? i_gp_reg_mapping->gp_reg_b : i_gp_reg_mapping->gp_reg_reduce_count,
+                                                       l_reg_b,
                                                        0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 
   /* compute fmopa */

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-main-2.0.0-1
+feature_improve_sme-2.0.0-3


### PR DESCRIPTION
Previously, only Transpose B was supported, and not all BRGEMM variants worked with the strided (strdbr) address mode. This PR adds Transpose A support and enables the strided BRGEMM path for the remaining cases, so both are now available for SME. Additionally, beta = 0 is now supported.

@stefan0re : please have a look