### PR TITLE
Add aarch64 CMake test

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         cmake -B build -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_INSTALL_PREFIX=$HOME/libxsmm-install \
           -DBUILD_TESTING=ON \
           -DBUILD_SHARED_LIBS=${{ matrix.shared == 'shared' && 'ON' || 'OFF' }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,11 +13,18 @@ on:
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    name: ${{ matrix.arch }} / ${{ matrix.shared }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        arch: [x86_64, aarch64]
         shared: [static, shared]
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v5
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ if(LIBXSMM_FORTRAN)
   enable_language(Fortran)
 endif()
 
+# Pass "-march=armv8.1-a" for Aarch64 build
+# to be consistent with GNU Makefile
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+  add_compile_options(-march=armv8.1-a)
+endif()
+
 # display config
 message(STATUS "******** Build Summary ********")
 message(STATUS "General:")

--- a/scripts/libxsmm_utilities.py
+++ b/scripts/libxsmm_utilities.py
@@ -337,26 +337,30 @@ def version_branch(max_strlen=-1):
 
 
 def libxsmm_target_arch():
-    libpath = os.path.join(os.path.dirname(__file__), "..", "lib")
+    libroot = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "..")
+    )
     uname = os.uname()
     oname = uname.sysname if not isinstance(uname, tuple) else uname[0]
     if "Darwin" == oname:
-        os.environ["DYLD_LIBRARY_PATH"] = libpath
         libext = ".dylib"
     else:
-        os.environ["LD_LIBRARY_PATH"] = libpath
         libext = ".so"
     os.environ["LIBXSMM_VERBOSE"] = "0"
-    xsmm = (
-        "libxsmm" + libext
-        if os.path.exists(os.path.join(libpath, "libxsmm" + libext))
-        else ctypes.util.find_library("xsmm")
-    )
+    libname = "libxsmm" + libext
+    xsmm = None
+    for libpath in (os.path.join(libroot, "lib"), libroot):
+        candidate = os.path.join(libpath, libname)
+        if os.path.isfile(candidate):
+            xsmm = candidate
+            break
+    if xsmm is None:
+        xsmm = ctypes.util.find_library("xsmm")
     target = "generic"
     try:
-        libxsmm = ctypes.CDLL(
-            os.path.join(libpath, xsmm), mode=ctypes.RTLD_GLOBAL
-        )
+        if xsmm is None:
+            raise OSError("LIBXSMM shared library not found")
+        libxsmm = ctypes.CDLL(xsmm, mode=ctypes.RTLD_GLOBAL)
         libxsmm_get_target_arch = libxsmm.libxsmm_get_target_arch
         libxsmm_get_target_arch.restype = ctypes.c_char_p
         target = libxsmm_get_target_arch().decode("ascii")

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-cmake_aarch64_test-2.0.0-16416
+cmake_aarch64_test-2.0.0-16417

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-cmake_aarch64_test-2.0.0-16415
+cmake_aarch64_test-2.0.0-16416

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-cmake_aarch64_test-2.0.0-16414
+cmake_aarch64_test-2.0.0-16415

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_bsrinit-2.0.0-4
+cmake_aarch64_test-2.0.0-16414


### PR DESCRIPTION
To keep an eye on CMake workflow on aarch64 architecture.

The flag `-march=armv8.1-a` is passed to CMake (consistent with GNU Makefile).