### PR TITLE
AArch64: use gp_reg_param_struct instead of hardcoded X0 in transform kernels

### DIFF
--- a/src/generator_mateltwise_transform_aarch64_asimd.c
+++ b/src/generator_mateltwise_transform_aarch64_asimd.c
@@ -1157,6 +1157,7 @@ void libxsmm_generator_transform_vnni2_to_vnni2t_16bit_aarch64_asimd_microkernel
 LIBXSMM_API_INTERN
 void libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_asimd_microkernel( libxsmm_generated_code*                 io_generated_code,
                                                                                   libxsmm_loop_label_tracker*             io_loop_label_tracker,
+                                                                                  const unsigned int                      i_gp_reg_param_struct,
                                                                                   const unsigned int                      i_gp_reg_in,
                                                                                   const unsigned int                      i_gp_reg_out,
                                                                                   const unsigned int                      i_gp_reg_m_loop,
@@ -1178,9 +1179,9 @@ void libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_asimd_microkernel
       libxsmm_generator_transform_vnni4_to_vnni4t_Nmod16_16bit_aarch64_asimd_microkernel( io_generated_code, io_loop_label_tracker,
                                                                                           i_gp_reg_in, i_gp_reg_out, i_gp_reg_m_loop, i_gp_reg_n_loop,
                                                                                           i_gp_reg_scratch, i_micro_kernel_config, &l_new_desc  );
-      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, LIBXSMM_AARCH64_GP_REG_X0, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_a,
+      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, i_gp_reg_param_struct, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_a,
                                             i_gp_reg_in );
-      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, LIBXSMM_AARCH64_GP_REG_X0, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_b,
+      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, i_gp_reg_param_struct, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_b,
                                             i_gp_reg_out );
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                  i_gp_reg_in, i_gp_reg_scratch, i_gp_reg_in, (long long)l_new_desc.n * l_new_desc.ldi * i_micro_kernel_config->datatype_size_in );
@@ -1365,6 +1366,7 @@ void libxsmm_generator_transform_aarch64_asimd_microkernel( libxsmm_generated_co
                                                                                    i_gp_reg_mapping->gp_reg_scratch_0, i_micro_kernel_config, i_mateltwise_desc );
     }  else if (libxsmm_meltw_descriptor_get_param(i_mateltwise_desc) == LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_VNNI4T) {
       libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_asimd_microkernel( io_generated_code, io_loop_label_tracker,
+                                                                                   i_gp_reg_mapping->gp_reg_param_struct,
                                                                                    i_gp_reg_mapping->gp_reg_in, i_gp_reg_mapping->gp_reg_out,
                                                                                    i_gp_reg_mapping->gp_reg_m_loop, i_gp_reg_mapping->gp_reg_n_loop,
                                                                                    i_gp_reg_mapping->gp_reg_scratch_0, i_micro_kernel_config, i_mateltwise_desc );

--- a/src/generator_mateltwise_transform_aarch64_asimd.h
+++ b/src/generator_mateltwise_transform_aarch64_asimd.h
@@ -241,6 +241,7 @@ void libxsmm_generator_transform_norm_to_vnni4_08bit_aarch64_asimd_microkernel( 
 LIBXSMM_API_INTERN
 void libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_asimd_microkernel( libxsmm_generated_code*                 io_generated_code,
                                                                                   libxsmm_loop_label_tracker*             io_loop_label_tracker,
+                                                                                  const unsigned int                      i_gp_reg_param_struct,
                                                                                   const unsigned int                      i_gp_reg_in,
                                                                                   const unsigned int                      i_gp_reg_out,
                                                                                   const unsigned int                      i_gp_reg_m_loop,

--- a/src/generator_mateltwise_transform_aarch64_sve.c
+++ b/src/generator_mateltwise_transform_aarch64_sve.c
@@ -620,6 +620,7 @@ void libxsmm_generator_transform_vnni4_to_vnni4t_Nmod16_16bit_aarch64_sve_microk
 LIBXSMM_API_INTERN
 void libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_sve_microkernel( libxsmm_generated_code*                 io_generated_code,
                                                                                 libxsmm_loop_label_tracker*             io_loop_label_tracker,
+                                                                                const unsigned int                      i_gp_reg_param_struct,
                                                                                 const unsigned int                      i_gp_reg_in,
                                                                                 const unsigned int                      i_gp_reg_out,
                                                                                 const unsigned int                      i_gp_reg_m_loop,
@@ -641,9 +642,9 @@ void libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_sve_microkernel( 
       libxsmm_generator_transform_vnni4_to_vnni4t_Nmod16_16bit_aarch64_sve_microkernel( io_generated_code, io_loop_label_tracker,
                                                                                         i_gp_reg_in, i_gp_reg_out, i_gp_reg_m_loop, i_gp_reg_n_loop,
                                                                                         i_gp_reg_scratch, i_micro_kernel_config, &l_new_desc  );
-      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, LIBXSMM_AARCH64_GP_REG_X0, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_a,
+      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, i_gp_reg_param_struct, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_a,
                                             i_gp_reg_in );
-      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, LIBXSMM_AARCH64_GP_REG_X0, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_b,
+      libxsmm_aarch64_instruction_alu_move( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_LDR_I_OFF, i_gp_reg_param_struct, LIBXSMM_AARCH64_GP_REG_UNDEF, l_offset_ptr_b,
                                             i_gp_reg_out );
       libxsmm_aarch64_instruction_alu_compute_imm64( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_META_ADD,
                                                  i_gp_reg_in, i_gp_reg_scratch, i_gp_reg_in, (long long)l_new_desc.n * l_new_desc.ldi * i_micro_kernel_config->datatype_size_in );
@@ -823,11 +824,13 @@ void libxsmm_generator_transform_aarch64_sve_microkernel( libxsmm_generated_code
     }  else if (libxsmm_meltw_descriptor_get_param(i_mateltwise_desc) == LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_VNNI4T) {
       if ( (io_generated_code->arch >= LIBXSMM_AARCH64_SVE256) && (io_generated_code->arch < LIBXSMM_AARCH64_SVE512) ) {
         libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_sve_microkernel( io_generated_code, io_loop_label_tracker,
+                                                                                   i_gp_reg_mapping->gp_reg_param_struct,
                                                                                    i_gp_reg_mapping->gp_reg_in, i_gp_reg_mapping->gp_reg_out,
                                                                                    i_gp_reg_mapping->gp_reg_m_loop, i_gp_reg_mapping->gp_reg_n_loop,
                                                                                    i_gp_reg_mapping->gp_reg_scratch_0, i_micro_kernel_config, i_mateltwise_desc );
       } else {
         libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_asimd_microkernel( io_generated_code, io_loop_label_tracker,
+                                                                                     i_gp_reg_mapping->gp_reg_param_struct,
                                                                                      i_gp_reg_mapping->gp_reg_in, i_gp_reg_mapping->gp_reg_out,
                                                                                      i_gp_reg_mapping->gp_reg_m_loop, i_gp_reg_mapping->gp_reg_n_loop,
                                                                                      i_gp_reg_mapping->gp_reg_scratch_0, i_micro_kernel_config, i_mateltwise_desc );

--- a/src/generator_mateltwise_transform_aarch64_sve.h
+++ b/src/generator_mateltwise_transform_aarch64_sve.h
@@ -107,6 +107,7 @@ void libxsmm_generator_transform_vnni4_to_vnni4t_Nmod16_16bit_aarch64_sve_microk
 LIBXSMM_API_INTERN
 void libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_sve_microkernel( libxsmm_generated_code*                 io_generated_code,
                                                                                 libxsmm_loop_label_tracker*             io_loop_label_tracker,
+                                                                                const unsigned int                      i_gp_reg_param_struct,
                                                                                 const unsigned int                      i_gp_reg_in,
                                                                                 const unsigned int                      i_gp_reg_out,
                                                                                 const unsigned int                      i_gp_reg_m_loop,

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-fix_905-2.1.0-21
+fix_aarch64_gpstruct_transform-2.1.0-21


### PR DESCRIPTION
### Problem
`libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_asimd_microkernel` and
`libxsmm_generator_transform_vnni4_to_vnni4t_16bit_aarch64_sve_microkernel` reload the
input/output pointers from the param struct when handling the `n > 16` remainder path.
Both used a hardcoded `LIBXSMM_AARCH64_GP_REG_X0` as the base register instead of the
register the caller actually mapped for the param struct
(`libxsmm_mateltwise_gp_reg_mapping::gp_reg_param_struct`).

This works today only because the mapping happens to assign `X0`
(`generator_mateltwise_aarch64.c`), so the kernels silently depend on that choice and
would emit wrong loads if the mapping ever changes or if these microkernels are reused
from a context with a different register assignment.

### Change
- Add an `i_gp_reg_param_struct` parameter to both microkernels, matching the existing
  convention of the neighboring `norm_to_vnni2` / `norm_to_vnni4` AArch64 microkernels.
- Use that parameter as the base register for the two `LDR` reloads instead of `X0`.
- Pass `i_gp_reg_mapping->gp_reg_param_struct` at all call sites (ASIMD dispatch, and the
  SVE dispatch for both the SVE and ASIMD fallback paths).
- Update the prototypes in the corresponding headers.

### Impact
No functional change to generated code today (the mapped register is `X0`), purely
removes an implicit assumption. No API/ABI change outside of `LIBXSMM_API_INTERN`
generator internals.
